### PR TITLE
This patch fixes c++ examples

### DIFF
--- a/include/metalchat/container.h
+++ b/include/metalchat/container.h
@@ -27,7 +27,7 @@ namespace metalchat {
 ///       \ref undeclare_mapped methods.
 ///
 /// Example usage:
-/// ```c++
+/// ```cpp
 /// basic_memfile file(std::ios::in | std::ios::out);
 ///
 /// const char* str = "this is a string";
@@ -163,7 +163,7 @@ private:
 /// \param ptr2 The secondary shared pointer (kept alive along with ptr1).
 ///
 /// Example usage:
-/// ```c++
+/// ```cpp
 /// auto ptr1 = std::make_shared<int>(1);
 /// auto ptr2 = std::make_shared<float>(2.0f);
 ///
@@ -211,7 +211,7 @@ struct basic_container {
 /// \tparam T The value type stored in the container.
 ///
 /// Example usage:
-/// ```c++
+/// ```cpp
 /// class custom_container : public memory_container<float> {
 /// private:
 ///     std::vector<float> _M_data;
@@ -443,7 +443,7 @@ template <contiguous_container Container> struct container_traits {
 /// \tparam T The value type.
 ///
 /// Example usage:
-/// ```c++
+/// ```cpp
 /// // Allocate raw memory.
 /// std::shared_ptr<void> storage = std::make_shared<float[]>(1024);
 ///
@@ -574,7 +574,7 @@ template <typename T> struct container_offset<random_memory_container<T>> {
 /// \tparam T The value type.
 ///
 /// Example usage:
-/// ```c++
+/// ```cpp
 /// auto storage = std::vector<int>({1, 2, 3, 4, 5});
 ///
 /// using Container = vector_memory_container<int>;
@@ -766,7 +766,7 @@ template <typename T> struct container_offset<hardware_memory_container<T>> {
 /// \tparam T The value type.
 ///
 /// Example usage:
-/// ```c++
+/// ```cpp
 /// using Container = scalar_memory_container<double>;
 /// auto container = std::make_shared<Container>(3.14159);
 ///
@@ -823,7 +823,7 @@ private:
 /// \tparam T The value type.
 ///
 /// Example usage:
-/// ```c++
+/// ```cpp
 /// auto storage = std::vector<float>({1.0f, 2.0f, 3.0f});
 ///
 /// using Container = filebuf_memory_container<float>;
@@ -986,7 +986,7 @@ template <typename T> struct container_offset<filebuf_memory_container<T>> {
 /// \tparam T The value type.
 ///
 /// Example usage:
-/// ```c++
+/// ```cpp
 /// using Container = vector_memory_container<int>;
 /// auto storage = std::vector<int32_t>({1, 2, 3, 4, 5});
 /// auto container_ptr = std::make_shared<Container>(storage);

--- a/include/metalchat/interpreter.h
+++ b/include/metalchat/interpreter.h
@@ -117,7 +117,7 @@ public:
     /// \param declaration A command declaration (i.e. JSON Schema by default).
     /// \param command A handler that returns the result of command execution.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto command = R"({
     /// "name":"multiply",
     /// "type": "function",
@@ -139,7 +139,7 @@ public:
     ///
     /// The variable should not start with $-expansion symbol.
     ///
-    /// ```c++
+    /// ```cpp
     /// interpreter interp(/* ... */);
     /// interp.declare_variable("my_var", R"(arbitrary text)");
     /// ```

--- a/include/metalchat/kernel.h
+++ b/include/metalchat/kernel.h
@@ -148,7 +148,7 @@ public:
     /// \param thread a size of 3-dimensional GPU compute thread group.
     /// \param args optional kernel arguments.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto accelerator = hardware_accelerator();
     /// auto kernel = accelerator.load<float, 16>("hadamard");
     ///

--- a/include/metalchat/kernel/arithmetic.h
+++ b/include/metalchat/kernel/arithmetic.h
@@ -101,7 +101,7 @@ public:
 ///
 /// \note The kernel performs true division. The kernel does not support type promotion.
 ///
-/// ```c++
+/// ```cpp
 /// auto input1 = tensor<float>({{3.0, 6.0, 9.0}});
 /// auto input2 = tensor<float>({{1.0, 2.0, 3.0}});
 ///

--- a/include/metalchat/kernel/copy.h
+++ b/include/metalchat/kernel/copy.h
@@ -103,7 +103,7 @@ public:
     ///
     /// \return a \ref future_tensor with the kernel operation result.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = tensor<float>({{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}});
     /// auto M = tensor<bool>({{true, false, false}, {false, true, true}});
     ///
@@ -139,7 +139,7 @@ public:
 
 /// Gathers values given the index tensor.
 ///
-/// ```c++
+/// ```cpp
 /// auto T = tensor<float>({{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}});
 /// auto index = tensor<int32_t>({{0, 0}, {1, 0}});
 ///

--- a/include/metalchat/kernel/sum.h
+++ b/include/metalchat/kernel/sum.h
@@ -61,7 +61,7 @@ public:
 
 /// Return the sum of each row of the `input` tensor in the last dimension.
 ///
-/// ```c++
+/// ```cpp
 /// auto input = tensor<float>({{1.0, 2.0, 3.0}, {3.0, 4.0, 5.0}});
 ///
 /// auto accelerator = hardware_accelerator();

--- a/include/metalchat/kernel_thread.h
+++ b/include/metalchat/kernel_thread.h
@@ -71,7 +71,7 @@ private:
     ///
     /// Consider the following kernel example, where the first parameter is passed by a value
     /// and the second by a pointer to the device data:
-    /// ```c++
+    /// ```cpp
     /// kernel void greater_than_value(
     ///     device float* input, constant float& value, device float* output
     /// );

--- a/include/metalchat/nn/layer.h
+++ b/include/metalchat/nn/layer.h
@@ -220,7 +220,7 @@ public:
     /// A common practice is registering upstream layers within a downstream layer constructor
     /// like in the example below.
     ///
-    /// ```c++
+    /// ```cpp
     /// using namespace metalchat;
     ///
     /// struct custom_layer : public basic_layer {
@@ -296,7 +296,7 @@ public:
     /// A common practice is registering parameters of the layers that could be updated
     /// externally (loaded from a file, or stored after inference):
     ///
-    /// ```c++
+    /// ```cpp
     /// using namespace metalchat;
     ///
     /// struct custom_layer : public basic_layer {
@@ -323,7 +323,7 @@ public:
     /// This method shared ownership of the tensor (parameter) with the caller. Consider the
     /// following example, where the parameter is constructed with the basic layer using
     /// delegated constructors, and then registered in the body of the constructor:
-    /// ```c++
+    /// ```cpp
     /// using namespace metalchat;
     ///
     /// struct custom_layer : public basic_layer {
@@ -353,7 +353,7 @@ public:
     ///
     /// Example:
     ///
-    /// ```c++
+    /// ```cpp
     /// using namespace metalchat;
     ///
     /// auto accelerator = hardware_accelerator(32);
@@ -571,7 +571,7 @@ polymorphic_layer<Layer>::operator=(indirect_layer<DerivedLayer>&& derived)
 ///
 /// \tparam Layer a type of the layers this module stores.
 ///
-/// ```c++
+/// ```cpp
 /// struct my_layer : public basic_layer {
 ///     // Step 1. Create a layer array as a type member.
 ///     layer_array<nn::linear<float>> linears;
@@ -768,7 +768,7 @@ struct layer_match_name {
 /// \param pred a predicate invoked for each layer in a search loop.
 /// \param generator a generator of \ref nn::indirect_layer instances used for replacement.
 ///
-/// ```c++
+/// ```cpp
 /// using namespace metalchat;
 ///
 /// using LLama3 = nn::llama3<bf16>;

--- a/include/metalchat/nn/sampling.h
+++ b/include/metalchat/nn/sampling.h
@@ -85,7 +85,7 @@ template <typename T> struct basic_sampler {
 ///
 /// Here is an example how to create the most common sampling strategy using a composition
 /// of \ref nucleus_sampler and \ref multinomial_sampler.
-/// ```c++
+/// ```cpp
 /// using namespace metalchat::nn;
 ///
 /// auto sampler = sequential_sampler<float>({

--- a/include/metalchat/safetensor.h
+++ b/include/metalchat/safetensor.h
@@ -313,7 +313,7 @@ private:
 /// public API for registering new, unsupported types.
 ///
 /// Here is an example of allocating a 128-element container of `int32_t` types in a heap:
-/// ```c++
+/// ```cpp
 /// using Allocator = random_memory_allocator<void>;
 /// safetensor_allocator<Allocator> dynamic_alloc;
 ///
@@ -569,7 +569,7 @@ public:
     /// \note It's guaranteed that tensors are returned in an order defined by their offset
     /// in a document.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto document = safetensor_document::open("model.safetensors");
     /// for (auto it = document.begin(); it != document.end(); ++it) {
     ///     std::cout << (*it) << std::endl;
@@ -747,7 +747,7 @@ public:
     /// to that container could be destroyed by a caller.
     ///
     /// Example:
-    /// ```c++
+    /// ```cpp
     /// auto weight = zeros<float>({3, 4});
     ///
     /// safetensor_document doc;
@@ -769,7 +769,7 @@ public:
     /// Both tensors will be sharing the same underlying container.
     ///
     /// Example:
-    /// ```c++
+    /// ```cpp
     /// auto weight = zeros<float>({3, 4});
     ///
     /// safetensor_document doc;
@@ -788,7 +788,7 @@ public:
     /// document.
     ///
     /// Example:
-    /// ```c++
+    /// ```cpp
     /// auto linear = nn::linear<float>({10, 64});
     ///
     /// safetensor_document doc;
@@ -850,7 +850,7 @@ public:
     /// document.
     ///
     /// Example:
-    /// ```c++
+    /// ```cpp
     /// hardware_accelerator accelerator;
     /// nn::linear<float> linear(accelerator);
     ///
@@ -883,7 +883,7 @@ public:
     /// \warning Tensor should be using the same container type as the safetensor document.
     ///
     /// Example:
-    /// ```c++
+    /// ```cpp
     /// tensor<float> target;
     /// auto doc = safetensor_document::open("linear.safetensors");
     /// doc.load("weight", target);

--- a/include/metalchat/tensor/basic.h
+++ b/include/metalchat/tensor/basic.h
@@ -148,7 +148,7 @@ largest_nested_size(std::initializer_list<std::initializer_list<T>> data)
 /// A tensor can be constructed from the `std::initializer_list` or by copying data from
 /// the various sources (see various tensor constructs below);
 ///
-/// ```c++
+/// ```cpp
 /// auto T = tensor({{1.0f, -1.0f}, {1.0f, -1.0f}});
 /// std::cout << T << std::endl;
 /// // out:
@@ -161,7 +161,7 @@ largest_nested_size(std::initializer_list<std::initializer_list<T>> data)
 /// A tensor of specific data type can be constructed by specified a concrete tensor type with
 /// a template parameter `T` and/or \ref allocator , \ref memory_container, or
 /// \ref hardware_accelerator, or tensor creation operation:
-/// ```c++
+/// ```cpp
 /// auto T = zeros<int32_t>({2, 4});
 /// std::cout << T << std::endl;
 /// // out:
@@ -226,7 +226,7 @@ public:
     /// \param value the value to initialize a tensor with.
     /// \param alloc allocator to use for all memory allocations of this container.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = tensor<float, 0, scalar_memory_container<float>>(3.0f);
     /// // Same as:
     /// auto S = scalar<float>(3.0f);
@@ -243,7 +243,7 @@ public:
     ///
     /// \param data initial data of the tensor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = tensor({1.0f, 2.0f, 3.0f, 4.0f});
     /// ```
     tensor(std::initializer_list<T> data) requires(N == 1)
@@ -259,7 +259,7 @@ public:
     ///
     /// \param data initial data of the tensor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = tensor({{1.0f, 2.0f, 3.0f}, {3.0f, 4.0f}});
     /// std::cout << T << std::endl;
     /// // out:
@@ -293,7 +293,7 @@ public:
     ///     to copy from.
     /// \param alloc allocator to use for all memory allocations of this container.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto sizes = std::vector({4, 3, 6, 7});
     /// auto T = tensor<float, 4>(sizes.begin(), sizes.end(), random_memory_allocator<float>());
     /// ```
@@ -318,7 +318,7 @@ public:
     /// \param data the contents that will be used as data for the tensor.
     /// \param alloc allocator to use for all memory allocations of this container.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto sizes = std::vector<std::size_t>({10, 2, 5});
     /// auto contents = std::vector<float>(100, 4.0f);
     ///
@@ -343,7 +343,7 @@ public:
     ///     to copy from.
     /// \param data initial data of the tensor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto sizes = std::vector<std::size_t>({4, 5});
     ///
     /// auto alloc = random_memory_allocator<float>();
@@ -364,7 +364,7 @@ public:
     /// \param sizes a sequence of unsigned integers defining the shape of the tensor.
     /// \param alloc allocator to use for all memory allocations of this container.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto sizes = std::vector<std::size_t>({4, 5});
     /// auto alloc = std::random_memory_allocator<float>();
     ///
@@ -382,7 +382,7 @@ public:
     /// \param sizes a sequence of unsigned integers defining the shape of the tensor.
     /// \param data initial data of the tensor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto sizes = std::vector<std::size_t>({4, 5});
     ///
     /// auto alloc = random_memory_allocator<float>();
@@ -399,7 +399,7 @@ public:
     /// \param sizes a sequence of unsigned integers defining the shape of the tensor.
     /// \param alloc allocator to use for all memory allocations of this container.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto alloc = random_memory_allocator<float>();
     /// auto T = tensor<float>({3, 4, 5}, alloc);
     /// ```
@@ -414,7 +414,7 @@ public:
     /// \param sizes a sequence of unsigned integers defining the shape of the tensor.
     /// \param data initial data of the tensor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto alloc = random_memory_allocator<float>();
     /// auto container_ptr = alloc.allocate(120);
     ///
@@ -432,7 +432,7 @@ public:
     /// \param access a tensor accessor defining the layout of data in the container.
     /// \param data initial data of the tensor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto alloc = random_memory_allocator<float>();
     /// auto container_ptr = alloc.allocate(120);
     ///
@@ -502,7 +502,7 @@ public:
     ///
     /// \param dim the dimension for which to retrieve the stride.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = empty<float>({2, 5});
     /// std::cout << T.stride(0) << std::endl;
     /// // out: 5
@@ -529,7 +529,7 @@ public:
 
     /// Returns strides of the tensor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = empty<float>({2, 5});
     /// std::cout << T.strides() << std::endl;
     /// // out: 5, 1
@@ -546,7 +546,7 @@ public:
     ///
     /// \param dim the dimension for which to retrieve the size.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = empty<float>({3, 4, 5});
     /// std::cout << T.size(1) << std::endl;
     /// // out: 4
@@ -569,7 +569,7 @@ public:
 
     /// Returns the sizes of the tensor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = empty<float>({3, 4, 5});
     /// std::cout << T.sizes() << std::endl;
     /// // out: 3, 4, 5
@@ -597,7 +597,7 @@ public:
     ///
     /// \param dim the dimension for which to retrieve the offset.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = empty<float>({3, 4, 5});
     /// auto S = T[slice(), slice(1, 3), slice()];
     /// std::cout << S.offset(1) << std::endl;
@@ -621,7 +621,7 @@ public:
 
     /// Returns the offsets of the tensor container.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = empty<float>({3, 4, 5});
     /// std::cout << T.offsets() << std::endl;
     /// // out: 0, 0, 0
@@ -648,7 +648,7 @@ public:
 
     /// Returns the total number of elements in the tensor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = rand<float>({1, 2, 3, 4, 5});
     /// std::cout << T.numel() << std::endl;
     /// // out: 120
@@ -707,7 +707,7 @@ public:
     /// Returns tensor's offset in the underlying storage in terms of number of storage elements
     /// (not bytes).
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = zeros<int32_t>({5});
     /// std::cout << T[slice(3), slice()].container_offset() << std::endl;
     /// // out: 3
@@ -735,7 +735,7 @@ public:
 
     /// Returns an iterator to the first element of a tensor.
     ///
-    /// ```c++
+    /// ```cpp
     /// #include <algorithm>
     ///
     /// auto T = rand<float>({4, 5, 6});
@@ -803,7 +803,7 @@ public:
     ///
     /// \param slices the slices of the tensor minor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = rand<float>({3, 4});
     /// const auto M = T[slice(0, 1), slice(1, 3)];
     /// ```
@@ -846,7 +846,7 @@ public:
     ///
     /// \param indices the indices of the element to access.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = rand<float>({3, 4});
     /// std::cout << T.value_select(0, 2) << std::endl;
     /// ```
@@ -895,7 +895,7 @@ public:
     /// \param start index of the element to start the narrowed dimension from.
     /// \param length length of the narrowed dimension.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = rand<float>({3, 3});
     /// std::cout << T.narrow(0, 0, 2).sizes() << std::endl;
     /// // out: 2, 3
@@ -922,7 +922,7 @@ public:
     /// acceleration kernels, therefore performance of this method is suboptimal. Consider using
     /// \ref kernel::clone for Metal-accelerated tensor copying.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = rand<float>({10, 10});
     /// auto M = zeros<float>({2, 2});
     ///
@@ -950,7 +950,7 @@ public:
     ///
     /// \param indices the indices of the element to access.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = rand<float>({3, 4});
     /// std::cout << T[0, 2] << std::endl;
     /// ```
@@ -973,7 +973,7 @@ public:
     ///
     /// \param slices the minors of the tensor to access.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = rand<float>({10, 20, 3});
     /// std::cout << T[slice(1, 4), slice(2, 4), slice(0, 2)] << std::endl;
     /// ```
@@ -998,7 +998,7 @@ public:
     ///
     /// \param dim position of the tensor minor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = rand<float>({4, 3, 4});
     /// std::cout << T[2].sizes() << std::endl;
     /// // out: 3, 4
@@ -1014,7 +1014,7 @@ public:
     ///
     /// \param dims dimensions to transpose
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = rand<float>({10, 4, 8, 128});
     /// std::cout << T.transpose({1, 0, 3, 2}) << std::endl;
     /// ```
@@ -1045,7 +1045,7 @@ public:
     ///
     /// \param dim position in the expanded shapew where the new dimension is placed.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = tensor({1.0f, 2.0f, 3.0f, 4.0f, 5.0f});
     /// std::cout << T.expand_dims(0) << std::endl;
     /// // out:
@@ -1091,7 +1091,7 @@ public:
     /// \tparam M a dimensionality of the new tensor.
     /// \param dims the desired tensor shape.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = rand<float>({4, 4});
     /// std::cout << T.sizes << std::endl;
     /// // out: 4, 4
@@ -1149,7 +1149,7 @@ public:
     /// dimensionality (M ≤ N). The resulting tensor is always a view of the original tensor data,
     /// therefore method raises an exception if it is not possible to create a view for the tensor.
     ///
-    /// ```c++
+    /// ```cpp
     /// auto T = rand<float>({2, 4, 8, 10});
     /// std::cout << T.flatten<2>().sizes() << std::endl;
     /// // out: 64, 10

--- a/include/metalchat/tensor/future.h
+++ b/include/metalchat/tensor/future.h
@@ -136,7 +136,7 @@ public:
     /// A new tensor will wait for completion of both self task and a new asynchronously
     /// invocable task, and only then makes result accessible.
     ///
-    /// ```c++
+    /// ```cpp
     /// #include <future>
     ///
     /// struct noop_async_func {

--- a/include/metalchat/tensor/iterator.h
+++ b/include/metalchat/tensor/iterator.h
@@ -33,7 +33,7 @@ concept forward_tensor_iterator_t = std::forward_iterator<It> && requires(It it)
 /// Usually \ref tensor_iterator is constructed using methods \ref tensor::begin and
 /// \ref tensor::end. But could also be used as a standalone entity.
 ///
-/// ```c++
+/// ```cpp
 /// auto T = rand<float>({3, 4});
 /// for (auto it = T.begin(); it != T.end(); ++it) {
 ///     std::cout << (*it) << std::endl;

--- a/include/metalchat/text/bpe.h
+++ b/include/metalchat/text/bpe.h
@@ -85,7 +85,7 @@ concept input_token_iterator_t = requires {
 /// ```
 ///
 /// Consider the following basic example:
-/// ```c++
+/// ```cpp
 /// using namespace metalchat::text;
 ///
 /// byte_pair_encoder<text::regexp> tokenizer("tokenizer.model");


### PR DESCRIPTION
This patch replaces `c++` syntax with `cpp` as in some version of sphinx/breathe this leads to incorrect rendering of the documentation.