### PR TITLE
Remove the usage of blocks in `add_broadcast` kernel

### DIFF
--- a/include/metalchat/kernel/arithmetic.h
+++ b/include/metalchat/kernel/arithmetic.h
@@ -64,19 +64,15 @@ public:
 
         auto max_threads = _M_kernel.max_threads_per_threadgroup();
 
-        auto q = double(dim0_size) / double(dim0_size + dim1_size);
-        auto threads_ratio = double(max_threads) * q;
+        auto q = double(dim0_size) / double(std::max(dim0_size, dim1_size));
+        auto threads_ratio = std::sqrt(double(max_threads)) * q;
 
         constexpr std::size_t one = 1;
         auto max_threads_x = std::max(one, std::size_t(threads_ratio));
         auto max_threads_y = std::max(one, std::size_t(std::floor(max_threads / max_threads_x)));
 
-
-        auto block_size_x = ceil_div(dim0_size, max_threads_x);
-        auto block_size_y = ceil_div(dim1_size, max_threads_y);
-
-        auto thread_size_x = ceil_div(dim0_size, block_size_x);
-        auto thread_size_y = ceil_div(dim1_size, block_size_y);
+        auto thread_size_x = ceil_div(dim0_size, max_threads_x);
+        auto thread_size_y = ceil_div(dim1_size, max_threads_y);
 
         auto thread = dim3(thread_size_x, thread_size_y);
 
@@ -84,9 +80,8 @@ public:
         auto grid_size_y = thread_size_y * ceil_div(dim1_size, thread_size_y);
         auto grid = dim3(grid_size_x, grid_size_y, num_batches);
 
-        auto block_size = scalar<uint32_t>(block_size_x);
         auto task = kernel_task(_M_kernel, grid, thread);
-        auto task_future = task.bind_front(output, input1, input2, block_size);
+        auto task_future = task.bind_front(output, input1, input2);
 
         return future_tensor(output, std::move(task_future));
     }

--- a/kernel/arithmetic.metal
+++ b/kernel/arithmetic.metal
@@ -53,7 +53,6 @@ template <typename T> struct __add_broadcast_parameters {
     device const T* input1;
     constant layout2& input2_layout;
     device const T* input2;
-    constant uint& block_size;
 };
 
 
@@ -74,15 +73,11 @@ add_broadcast(
     const uint dim1_size = in2.size(1);
     const uint i = gid.z;
 
-    const uint begin = gid.x * threadgroup_size.x + tid.x * params.block_size;
-    const uint end = begin + params.block_size;
-
+    const uint j = gid.x * threadgroup_size.x + tid.x;
     const uint k = gid.y * threadgroup_size.y + tid.y;
 
-    if (k < dim0_size) {
-        for (uint j = begin; j < end && j < dim0_size; j++) {
-            out.at(i, j, k) = in1.at(i, j, k) + in2.at(j, k);
-        }
+    if (j < dim1_size && k < dim0_size) {
+        out.at(i, j, k) = in1.at(i, j, k) + in2.at(j, k);
     }
 }
 

--- a/kernel/arithmetic.metal
+++ b/kernel/arithmetic.metal
@@ -76,7 +76,7 @@ add_broadcast(
     const uint j = gid.x * threadgroup_size.x + tid.x;
     const uint k = gid.y * threadgroup_size.y + tid.y;
 
-    if (j < dim1_size && k < dim0_size) {
+    if (j < dim0_size && k < dim1_size) {
         out.at(i, j, k) = in1.at(i, j, k) + in2.at(j, k);
     }
 }

--- a/kernel/arithmetic.metal
+++ b/kernel/arithmetic.metal
@@ -71,12 +71,12 @@ add_broadcast(
 
     const uint dim0_size = in2.size(0);
     const uint dim1_size = in2.size(1);
+
+    const uint k = gid.x * threadgroup_size.x + tid.x;
+    const uint j = gid.y * threadgroup_size.y + tid.y;
     const uint i = gid.z;
 
-    const uint j = gid.x * threadgroup_size.x + tid.x;
-    const uint k = gid.y * threadgroup_size.y + tid.y;
-
-    if (j < dim0_size && k < dim1_size) {
+    if (j < dim1_size && k < dim0_size) {
         out.at(i, j, k) = in1.at(i, j, k) + in2.at(j, k);
     }
 }


### PR DESCRIPTION
This patch removes the usage of tiling blocks from the `add_broadcast` kernel.