### PR TITLE
Simplify kernel scheduling of `add_broadcast` operation

### DIFF
--- a/include/metalchat/kernel/arithmetic.h
+++ b/include/metalchat/kernel/arithmetic.h
@@ -46,52 +46,33 @@ public:
     : _M_kernel(gpu.load<T>("add_broadcast"))
     {}
 
-    template <immutable_tensor3_t<T> Input1, immutable_tensor2_t<T> Input2>
+    template <immutable_tensor2_t<T> Input1, immutable_tensor1_t<T> Input2>
     auto
     operator()(Input1 input1, Input2 input2)
     {
-        constexpr auto M = Input1::dim();
-
-        auto expected_input1 =
-            expected_tensor(input1).same_dim(input2, M - 2, 0).same_dim(input2, M - 1, 1).value();
-
-        auto dim0_size = input2.size(0);
-        auto dim1_size = input2.size(1);
-        auto num_batches = input1.sizes().front();
+        auto expected_input1 = expected_tensor(input1).same_dim(input2, 1, 0).value();
 
         auto alloc = _M_kernel.get_allocator();
-        auto output = shared_empty_like<T>(input1, alloc);
+        auto output = shared_empty_like<T>(expected_input1, alloc);
 
         auto max_threads = _M_kernel.max_threads_per_threadgroup();
-
-        auto q = double(dim0_size) / double(std::max(dim0_size, dim1_size));
-        auto threads_ratio = std::sqrt(double(max_threads)) * q;
-
-        constexpr std::size_t one = 1;
-        auto max_threads_x = std::max(one, std::size_t(threads_ratio));
-        auto max_threads_y = std::max(one, std::size_t(std::floor(max_threads / max_threads_x)));
-
-        auto thread_size_x = ceil_div(dim0_size, max_threads_x);
-        auto thread_size_y = ceil_div(dim1_size, max_threads_y);
-
-        auto thread = dim3(thread_size_x, thread_size_y);
-
-        auto grid_size_x = thread_size_x * ceil_div(dim0_size, thread_size_x);
-        auto grid_size_y = thread_size_y * ceil_div(dim1_size, thread_size_y);
-        auto grid = dim3(grid_size_x, grid_size_y, num_batches);
+        auto [grid, thread] = make_kernel_grid_2d(expected_input1, max_threads);
 
         auto task = kernel_task(_M_kernel, grid, thread);
-        auto task_future = task.bind_front(output, input1, input2);
+        auto task_future = task.bind_front(output, expected_input1, input2);
 
         return future_tensor(output, std::move(task_future));
     }
 
-    template <immutable_tensor_t<T> Input1, immutable_tensor2_t<T> Input2>
-    requires(Input1::dim() > 3)
+    template <immutable_tensor_t<T> Input1, immutable_tensor_t<T> Input2>
+    requires(Input1::dim() > 2 && Input2::dim() >= 2)
     auto
     operator()(Input1 input1, Input2 input2)
     {
-        auto output = operator()(flatten<3>(input1), input2);
+        auto input2_flat = flatten<1>(input2);
+        auto bcast_dim = static_cast<int32_t>(input2_flat.size(0));
+
+        auto output = operator()(input1.view({-1, bcast_dim}), input2_flat);
         return output.view(input1.shape());
     }
 };

--- a/include/metalchat/kernel/embedding.h
+++ b/include/metalchat/kernel/embedding.h
@@ -45,7 +45,7 @@ public:
         // size of the weight. Depending on this ratio more threads of a single group,
         // a larger or smaller block size is used to iterate over input dimension.
         auto q = double(dim_size) / double(emb_size + dim_size);
-        auto threads_ratio = double(max_threads) * q;
+        auto threads_ratio = std::sqrt(double(max_threads)) * q;
 
         constexpr std::size_t one = 1;
         auto max_threads_x = std::max(one, std::size_t(threads_ratio));

--- a/kernel/arithmetic.metal
+++ b/kernel/arithmetic.metal
@@ -47,11 +47,11 @@ __lib_metalchat_kernel2(add, float);
 
 
 template <typename T> struct __add_broadcast_parameters {
-    constant layout3& output_layout;
+    constant layout2& output_layout;
     device T* output;
-    constant layout3& input1_layout;
+    constant layout2& input1_layout;
     device const T* input1;
-    constant layout2& input2_layout;
+    constant layout1& input2_layout;
     device const T* input2;
 };
 
@@ -60,30 +60,29 @@ template <typename T>
 kernel void
 add_broadcast(
     __add_broadcast_parameters<T> params,
-    uint3 gid [[threadgroup_position_in_grid]],
-    uint3 tid [[thread_position_in_threadgroup]],
-    uint3 threadgroup_size [[threads_per_threadgroup]]
+    uint2 gid [[threadgroup_position_in_grid]],
+    uint2 tid [[thread_position_in_threadgroup]],
+    uint2 threadgroup_size [[threads_per_threadgroup]]
 )
 {
-    tensor3<const T> in1(params.input1_layout, params.input1);
-    tensor2<const T> in2(params.input2_layout, params.input2);
-    tensor3<T> out(params.output_layout, params.output);
+    tensor2<const T> in1(params.input1_layout, params.input1);
+    tensor1<const T> in2(params.input2_layout, params.input2);
+    tensor2<T> out(params.output_layout, params.output);
 
-    const uint dim0_size = in2.size(0);
-    const uint dim1_size = in2.size(1);
+    const uint dim0_size = in1.size(0);
+    const uint dim1_size = in1.size(1);
 
-    const uint k = gid.x * threadgroup_size.x + tid.x;
-    const uint j = gid.y * threadgroup_size.y + tid.y;
-    const uint i = gid.z;
+    const uint j = gid.x * threadgroup_size.x + tid.x;
+    const uint i = gid.y * threadgroup_size.y + tid.y;
 
-    if (j < dim1_size && k < dim0_size) {
-        out.at(i, j, k) = in1.at(i, j, k) + in2.at(j, k);
+    if (i < dim0_size && j < dim1_size) {
+        out.at(i, j) = in1.at(i, j) + in2.at(j % in2.size(0));
     }
 }
 
 
-__lib_metalchat_kernel3(add_broadcast, bfloat);
-__lib_metalchat_kernel3(add_broadcast, float);
+__lib_metalchat_kernel2(add_broadcast, bfloat);
+__lib_metalchat_kernel2(add_broadcast, float);
 
 
 template <typename T> struct __sub_parameters {


### PR DESCRIPTION
This patch simplifies the kernel scheduling of a broadcasted add operation, so it adds 2-dim tensor and 1-dim tensor.