### PR TITLE
Remove block-tiling from hadamard-bcast operation

### DIFF
--- a/include/metalchat/functional/primitive.h
+++ b/include/metalchat/functional/primitive.h
@@ -48,11 +48,7 @@ hadamard(Tensor1 t1, Tensor2 t2, hardware_accelerator& gpu)
 }
 
 
-template <
-    typename T,
-    immutable_tensor Tensor1,
-    immutable_tensor Tensor2,
-    std::size_t BlockSize = 16>
+template <typename T, immutable_tensor Tensor1, immutable_tensor Tensor2>
 auto
 hadamard_broadcast(Tensor1 t1, Tensor2 t2, hardware_accelerator& gpu)
 {

--- a/include/metalchat/kernel/arithmetic.h
+++ b/include/metalchat/kernel/arithmetic.h
@@ -69,10 +69,10 @@ public:
     auto
     operator()(Input1 input1, Input2 input2)
     {
-        auto input2_flat = flatten<1>(input2);
-        auto bcast_dim = static_cast<int32_t>(input2_flat.size(0));
+        auto input2_view = flatten<1>(input2);
+        auto input2_dim = static_cast<int32_t>(input2_view.size(0));
 
-        auto output = operator()(input1.view({-1, bcast_dim}), input2_flat);
+        auto output = operator()(input1.view({-1, input2_dim}), input2_view);
         return output.view(input1.shape());
     }
 };

--- a/include/metalchat/kernel/mul.h
+++ b/include/metalchat/kernel/mul.h
@@ -34,29 +34,24 @@ public:
 };
 
 
-template <typename T, typename I1, typename I2, std::size_t BlockSize = 16>
-class hadamard_broadcast {
+template <typename T, typename I1, typename I2> class hadamard_broadcast {
 private:
     basic_kernel _M_kernel;
 
 public:
     hadamard_broadcast(hardware_accelerator& gpu)
-    : _M_kernel(gpu.load<T, I1, I2>("hadamard_broadcast", BlockSize))
+    : _M_kernel(gpu.load<T, I1, I2>("hadamard_broadcast"))
     {}
 
-    template <immutable_tensor2_t<I1> Input1, immutable_tensor2_t<I2> Input2>
+    template <immutable_tensor2_t<I1> Input1, immutable_tensor1_t<I2> Input2>
     auto
     operator()(Input1 input1, Input2 input2)
     {
         auto expected_input1 = expected_tensor(input1).same_first_dim(input2).value();
-        auto expected_input2 = expected_tensor(input2).same_dim(1, /*expect=*/1).value();
+        auto expected_input2 = input2;
 
         auto max_threads = _M_kernel.max_threads_per_threadgroup();
-        auto num_rows = ceil_div(input1.size(0), BlockSize);
-        auto num_dims = ceil_div(input1.size(1), BlockSize);
-
-        auto thread = dim3(ceil_div(max_threads, num_dims), num_dims);
-        auto grid = dim3(ceil_div(num_rows, thread.x) * thread.x, thread.y);
+        auto [grid, thread] = make_kernel_grid_2d(expected_input1, max_threads);
 
         auto output = shared_empty_like<T>(input1, _M_kernel.get_allocator());
 
@@ -66,17 +61,16 @@ public:
         return future_tensor(output, std::move(task_future));
     }
 
-    template <immutable_tensor3_t<I1> Input1, immutable_tensor3_t<I2> Input2>
+    template <immutable_tensor_t<I1> Input1, immutable_tensor_t<I2> Input2>
+    requires(Input1::dim() >= 2 && Input2::dim() >= 2)
     auto
     operator()(Input1 input1, Input2 input2)
     {
-        auto expected_input1 = expected_tensor(input1).same_dim(input2, 1, 1).value();
-
-        auto input1_view = flatten<2>(expected_input1);
-        auto input2_view = flatten<2>(input2);
+        auto input1_view = flatten<2>(input1);
+        auto input2_view = flatten<1>(input2);
 
         auto output = operator()(input1_view, input2_view);
-        return output.view(expected_input1.shape());
+        return output.view(input1.shape());
     }
 };
 

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -71,16 +71,6 @@ template <typename T> T inline __ceil_div(T a, T b) { return (a + b - 1) / b; }
     )
 
 
-#define __lib_metalchat_kernel2_mixed3_tiled(function_name, block_size, type1, type2, type3) \
-    template [[host_name(                                                                    \
-        __lib_metalchat_concatenate5(function_name, block_size, type1, type2, type3)         \
-    )]]                                                                                      \
-    kernel void                                                                              \
-    function_name<type1, type2, type3, block_size>(                                          \
-        __##function_name##_parameters<type1, type2, type3>, uint2, uint2, uint2             \
-    )
-
-
 /// A macro renders the function prototype of a metal kernel with 3-dimensional execution grid.
 ///
 /// Use this macro for kernels that do not use block-tiling.

--- a/kernel/mul.metal
+++ b/kernel/mul.metal
@@ -52,11 +52,11 @@ template <typename Output, typename Input1, typename Input2>
 struct __hadamard_broadcast_parameters {
     tensor2<Output> output;
     tensor2<const Input1> input1;
-    tensor2<const Input2> input2;
+    tensor1<const Input2> input2;
 };
 
 
-template <typename Output, typename Input1, typename Input2, uint BlockSize>
+template <typename Output, typename Input1, typename Input2>
 kernel void
 hadamard_broadcast(
     __hadamard_broadcast_parameters<Output, Input1, Input2> params,
@@ -65,30 +65,24 @@ hadamard_broadcast(
     uint2 threadgroup_size [[threads_per_threadgroup]]
 )
 {
-    const uint row_size = params.output.size(0);
-    const uint dim_size = params.output.size(1);
+    const uint dim0_size = params.input1.size(0);
+    const uint dim1_size = params.input1.size(1);
 
-    const uint ibegin = (gid.x * threadgroup_size.x + tid.x) * BlockSize;
-    const uint iend = ibegin + BlockSize;
+    const uint j = gid.x * threadgroup_size.x + tid.x;
+    const uint i = gid.y * threadgroup_size.y + tid.y;
 
-    for (uint i = ibegin; i < iend && i < row_size; i++) {
-        const uint kbegin = tid.y * BlockSize;
-        const uint kend = kbegin + BlockSize;
-
-#pragma unroll(BlockSize)
-        for (uint k = kbegin; k < kend && k < dim_size; k++) {
-            params.output.at(i, k) =
-                (static_cast<Output>(params.input1.at(i, k)) *
-                 static_cast<Output>(params.input2.at(i, 0)));
-        }
+    if (i < dim0_size && j < dim1_size) {
+        params.output.at(i, j) =
+            (static_cast<Output>(params.input1.at(i, j)) *
+             static_cast<Output>(params.input2.at(i % params.input2.size(0))));
     }
 }
 
 
-__lib_metalchat_kernel2_mixed3_tiled(hadamard_broadcast, 16, bfloat, int8_t, bfloat);
-__lib_metalchat_kernel2_mixed3_tiled(hadamard_broadcast, 16, bfloat, int8_t, float);
-__lib_metalchat_kernel2_mixed3_tiled(hadamard_broadcast, 16, float, int8_t, bfloat);
-__lib_metalchat_kernel2_mixed3_tiled(hadamard_broadcast, 16, float, int8_t, float);
+__lib_metalchat_kernel2_mixed3(hadamard_broadcast, bfloat, int8_t, bfloat);
+__lib_metalchat_kernel2_mixed3(hadamard_broadcast, bfloat, int8_t, float);
+__lib_metalchat_kernel2_mixed3(hadamard_broadcast, float, int8_t, bfloat);
+__lib_metalchat_kernel2_mixed3(hadamard_broadcast, float, int8_t, float);
 
 
 template <typename T> struct __scalar_mul_parameters {


### PR DESCRIPTION
This patch removes block-tiling kernel implementation from hadamard broadcasted multiplication and replaces it with grid-scheduled one.