### PR TITLE
Move token termination strategy to a separate class hierarchy

### DIFF
--- a/.github/workflows/cxx_unit_tests.yaml
+++ b/.github/workflows/cxx_unit_tests.yaml
@@ -35,10 +35,14 @@ jobs:
 
     - name: Detect build profile
       id: setup_profile
-      run: >
-        pipenv run
-        conan profile detect
-        sed -i 's/compiler.version=\d+/compiler.version=17/d' $(conan profile path default)
+      run: |
+        pipenv run conan profile detect
+        echo "path=$(pipenv run conan profile detect)" >> "$GITHUB_OUTPUT"
+
+    - name: Patch compiler version
+      id: patch_profile
+      run: |
+        sed -i 's/compiler.version=\d+/compiler.version=17/d' ${{ steps.setup_profile.outputs.path }}
 
     # The building command uses the system libraries (OpenSSL, and libcurl) to avoid
     # long compilation time in the CI. Also unit tests do not launch integration tests

--- a/.github/workflows/cxx_unit_tests.yaml
+++ b/.github/workflows/cxx_unit_tests.yaml
@@ -38,6 +38,7 @@ jobs:
       run: >
         pipenv run
         conan profile detect
+        sed -i 's/compiler.version=\d+/compiler.version=17/d' $(conan profile path default)
 
     # The building command uses the system libraries (OpenSSL, and libcurl) to avoid
     # long compilation time in the CI. Also unit tests do not launch integration tests
@@ -52,7 +53,6 @@ jobs:
         conan build
         --build=missing
         --settings build_type=Release
-        --settings compiler.version=17
         --options '&:build_executable'=True
         --options '&:use_system_libs'=True
         --conf tools.build:skip_test=False

--- a/.github/workflows/cxx_unit_tests.yaml
+++ b/.github/workflows/cxx_unit_tests.yaml
@@ -37,7 +37,7 @@ jobs:
       id: setup_profile
       run: |
         pipenv run conan profile detect
-        echo "path=$(pipenv run conan profile detect)" >> "$GITHUB_OUTPUT"
+        echo "path=$(pipenv run conan profile path default)" >> "$GITHUB_OUTPUT"
 
     - name: Patch compiler version
       id: patch_profile

--- a/.github/workflows/cxx_unit_tests.yaml
+++ b/.github/workflows/cxx_unit_tests.yaml
@@ -37,7 +37,8 @@ jobs:
       id: setup_profile
       run: |
         pipenv run conan profile detect
-        echo "path=$(pipenv run conan profile path default)" >> "$GITHUB_OUTPUT"
+        echo -n $(pipenv run conan profile path default)
+        echo -n "path=$(pipenv run conan profile path default)" >> "$GITHUB_OUTPUT"
 
     - name: Patch compiler version
       id: patch_profile

--- a/.github/workflows/cxx_unit_tests.yaml
+++ b/.github/workflows/cxx_unit_tests.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Patch compiler version
       id: patch_profile
       run: |
-        sed -i 's/compiler.version=\d+/compiler.version=17/d' ${{ steps.setup_profile.outputs.path }}
+        sed -i '' 's/compiler.version=.*/compiler.version=17/' ${{ steps.setup_profile.outputs.path }}
 
     # The building command uses the system libraries (OpenSSL, and libcurl) to avoid
     # long compilation time in the CI. Also unit tests do not launch integration tests

--- a/.github/workflows/cxx_unit_tests.yaml
+++ b/.github/workflows/cxx_unit_tests.yaml
@@ -52,6 +52,7 @@ jobs:
         conan build
         --build=missing
         --settings build_type=Release
+        --settings compiler.version=17
         --options '&:build_executable'=True
         --options '&:use_system_libs'=True
         --conf tools.build:skip_test=False

--- a/include/metalchat/interpreter.h
+++ b/include/metalchat/interpreter.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <iostream>
+#include <iterator>
 #include <optional>
 
 #include <metalchat/command.h>
@@ -67,6 +68,123 @@ private:
 };
 
 
+class basic_token_scanner {
+public:
+    using index_type = int32_t;
+
+    virtual void
+    reset() = 0;
+
+    virtual bool
+    scan(index_type token) = 0;
+
+    /// The default /ref basic_token_scanner destructor.
+    virtual ~basic_token_scanner() {}
+};
+
+
+class match_token_scanner : public basic_token_scanner {
+public:
+    match_token_scanner(std::initializer_list<index_type> tokens)
+    : match_token_scanner(tokens.begin(), tokens.end())
+    {}
+
+    template <std::forward_iterator ForwardIt>
+    match_token_scanner(ForwardIt first, ForwardIt last)
+        requires std::same_as<std::iter_value_t<ForwardIt>, index_type>
+    : _M_tokens(first, last)
+    {}
+
+    void
+    reset()
+    {}
+
+    bool
+    scan(index_type token)
+    {
+        return _M_tokens.find(token) == _M_tokens.end();
+    }
+
+private:
+    std::unordered_set<index_type> _M_tokens;
+};
+
+
+class limit_token_scanner : public basic_token_scanner {
+public:
+    limit_token_scanner(std::size_t lim)
+    : _M_lim(lim),
+      _M_scanned(0)
+    {}
+
+    void
+    reset()
+    {
+        _M_scanned = 0;
+    }
+
+    bool
+    scan(index_type token)
+    {
+        return (++_M_scanned) < _M_lim;
+    }
+
+private:
+    std::size_t _M_lim;
+    std::size_t _M_scanned;
+};
+
+
+template <typename LogicalOp> class composite_token_scanner : public basic_token_scanner {
+public:
+    using scanner_type = basic_token_scanner;
+    using scanner_pointer = std::shared_ptr<scanner_type>;
+
+    composite_token_scanner(std::initializer_list<scanner_pointer> scanners)
+    : composite_token_scanner(scanners.begin(), scanners.end())
+    {}
+
+    template <std::forward_iterator ForwardIt>
+    composite_token_scanner(ForwardIt first, ForwardIt last)
+        requires std::same_as<std::iter_value_t<ForwardIt>, scanner_pointer>
+    : _M_scanners(std::make_move_iterator(first), std::make_move_iterator(last)),
+      _M_logical_op()
+    {}
+
+    /// The default \ref composite_token_scanner constructor.
+    composite_token_scanner()
+    : composite_token_scanner({})
+    {}
+
+    void
+    reset()
+    {
+        for (auto& scanner : _M_scanners) {
+            scanner->reset();
+        }
+    }
+
+    bool
+    scan(index_type token)
+    {
+        bool result = false;
+        if (_M_scanners.size() == 0) {
+            return result;
+        }
+
+        result = _M_scanners.front()->scan(token);
+        for (std::size_t i = 1; i < _M_scanners.size(); i++) {
+            result = _M_logical_op(result, _M_scanners[i]->scan(token));
+        }
+        return result;
+    }
+
+private:
+    std::vector<scanner_pointer> _M_scanners;
+    LogicalOp _M_logical_op;
+};
+
+
 /// Each message submitted to the interpreter is being passed through the mustache render engine,
 /// so all valid mustache sequences are expanded with appropriate variable values.
 class interpreter {
@@ -105,6 +223,17 @@ public:
         const text::bpe& encoder,
         std::size_t max_pos = -1
     );
+
+    void
+    set_token_scanner(std::shared_ptr<basic_token_scanner> scanner);
+
+    template <std::derived_from<basic_token_scanner> Scanner>
+    void
+    set_token_scanner(Scanner&& scanner)
+    {
+        auto scanner_ptr = std::make_shared<Scanner>(std::move(scanner));
+        set_token_scanner(scanner_ptr);
+    }
 
     /// Declare the command available for execution.
     ///
@@ -204,6 +333,7 @@ public:
 private:
     std::shared_ptr<_Members> _M_members;
     std::shared_ptr<basic_transformer> _M_transformer;
+    std::shared_ptr<basic_token_scanner> _M_token_scanner;
     std::shared_ptr<basic_command_scanner> _M_command_scanner;
     std::unordered_map<std::string, command_type> _M_commands;
     text::bpe _M_encoder;
@@ -238,13 +368,12 @@ private:
     tensor_type
     read_until(OutputIt it)
     {
+        _M_token_scanner->reset();
+
         auto stream = flush();
         auto token = stream.get()[0, 0];
 
-        auto end_turn = _M_encoder.encode(text::token::end_turn);
-        auto end_message = _M_encoder.encode(text::token::end_message);
-
-        while (token != end_turn && token != end_message) {
+        while (_M_token_scanner->scan(token)) {
             *it++ = _M_encoder.decode(token);
             stream = _M_transformer->transform(stream, _M_start_pos++);
             token = stream.get()[0, 0];

--- a/program/program.cc
+++ b/program/program.cc
@@ -97,6 +97,12 @@ program::transform(const program_scope& scope, const std::string& prompt) const
     auto tokenizer = repo.retrieve_tokenizer();
 
     auto interp = metalchat::interpreter(transformer, tokenizer);
+    // TODO: extract terminal tokens from the huggingface tokenizer configuration.
+    interp.set_token_scanner(match_token_scanner(
+        {tokenizer.encode(text::token::end_text), tokenizer.encode(text::token::end_turn),
+         tokenizer.encode(text::token::end_message)}
+    ));
+
     auto system_prompt = scope.manifest.system_prompt(scope.path);
     if (system_prompt) {
         interp.write(basic_message("system", system_prompt.value()));

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -74,6 +74,7 @@ interpreter::interpreter(
 )
 : _M_members(std::make_shared<_Members>()),
   _M_transformer(transformer_ptr),
+  _M_token_scanner(std::make_shared<limit_token_scanner>(50)),
   _M_command_scanner(std::make_shared<json_command_scanner>()),
   _M_commands(),
   _M_encoder(encoder),
@@ -84,6 +85,13 @@ interpreter::interpreter(
     // Do not escape characters, leave them as is. This is the global configuration,
     // so unfortunately this line changes behaviour for the whole library.
     mustache::config::escape = [](const std::string& str) -> std::string { return str; };
+}
+
+
+void
+interpreter::set_token_scanner(std::shared_ptr<basic_token_scanner> scanner)
+{
+    _M_token_scanner = scanner;
 }
 
 

--- a/test/test_interpreter.cc
+++ b/test/test_interpreter.cc
@@ -17,6 +17,22 @@
 using namespace metalchat;
 
 
+namespace testing {
+
+auto
+make_token_scanner()
+{
+    auto terminal_tokens_scanner = match_token_scanner({128001, 128008, 128009});
+
+    return composite_token_scanner<std::logical_and<bool>>(
+        {std::make_shared<limit_token_scanner>(100),
+         std::make_shared<match_token_scanner>(std::move(terminal_tokens_scanner))}
+    );
+}
+
+} // namespace testing
+
+
 TEST_CASE("Test interpreter", "[llama][integration]")
 {
     auto repo_path = test_fixture_path() / "meta-llama/Llama-3.2-1B-Instruct/original";
@@ -27,6 +43,7 @@ TEST_CASE("Test interpreter", "[llama][integration]")
     auto transformer = repository.retrieve_transformer("model.safetensors", options);
 
     auto interp = interpreter(transformer, tokenizer);
+    interp.set_token_scanner(testing::make_token_scanner());
 
     auto command = R"({"name":"multiply",
 "type": "function",
@@ -82,6 +99,7 @@ TEST_CASE("Test filebuf interpreter", "[llama][integration]")
     auto transformer = repository.retrieve_transformer("model.safetensors", options, Allocator());
 
     auto interp = interpreter(transformer, tokenizer);
+    interp.set_token_scanner(testing::make_token_scanner());
 
     interp.write(basic_message("system", "You are a helpful assistant"));
     interp.write(basic_message("user", "What is the capital of Germany?"));


### PR DESCRIPTION
This patch moves the interpreter (generator) termination from the `read_until` loop to the separate class hierarchy defined by a `basic_token_scanner` base class.