### PR TITLE
Introduce a method `safetensor_document::rename`

### DIFF
--- a/include/metalchat/huggingface/llama.h
+++ b/include/metalchat/huggingface/llama.h
@@ -86,8 +86,6 @@ public:
     safetensor_document
     adapt(const safetensor_document& document) const
     {
-        safetensor_document doc;
-
         const std::vector<std::pair<std::regex, std::string>> mapping = {
             {std::regex(R"(model\.(layers\.\d+)\.input_layernorm)"), "$1.attention_norm"},
             {std::regex(R"(model\.(layers\.\d+)\.post_attention_layernorm)"), "$1.ffn_norm"},
@@ -102,21 +100,9 @@ public:
             {std::regex(R"(model.embed_tokens)"), "tok_embeddings"},
         };
 
-        for (auto it = document.begin(); it != document.end(); ++it) {
-            auto st = *it;
-            auto name = st.name();
-
-            for (const auto& [re, replacement] : mapping) {
-                name = std::regex_replace(name, re, replacement);
-            }
-
-            auto sizes = st.sizes();
-            auto shape = std::vector<std::size_t>(sizes.begin(), sizes.end());
-
-            doc.insert(safetensor(name, st.dtype(), shape, st.container_ptr()));
-        }
-
+        auto doc = document.rename(mapping.begin(), mapping.end());
         doc.insert("output.weight", "tok_embeddings.weight");
+
         return doc;
     }
 

--- a/include/metalchat/nn/transformer.h
+++ b/include/metalchat/nn/transformer.h
@@ -70,12 +70,15 @@ public:
 };
 
 
-template <typename T, contiguous_container Container = hardware_memory_container<T>>
+template <
+    typename T,
+    contiguous_container Container = hardware_memory_container<T>,
+    typename Activation = kernel::silu<T>>
 class transformer : public basic_layer {
 private:
     using RMSNorm = nn::rmsnorm<T, Container>;
     using Attention = nn::attention<T, Container>;
-    using FeedForward = nn::feed_forward<T, Container>;
+    using FeedForward = nn::feed_forward<T, Container, Activation>;
 
     indirect_layer<Attention> _M_attention;
     indirect_layer<RMSNorm> _M_attention_norm;
@@ -100,12 +103,15 @@ public:
     auto
     operator()(Input input, Cache& cache, std::size_t start_pos = 0)
     {
-        auto norm = _M_attention_norm(input);
-        auto h = add(input, _M_attention(norm, cache, start_pos), accelerator());
+        auto hidden_states = _M_attention_norm(input);
+        hidden_states = _M_attention(hidden_states, cache, start_pos);
+        hidden_states = add(input, hidden_states, accelerator());
 
-        auto ff_norm = _M_ff_norm(h);
-        auto result = add(h, _M_ff(ff_norm), accelerator());
-        return result;
+        auto residual = hidden_states;
+        hidden_states = _M_ff_norm(hidden_states);
+        hidden_states = _M_ff(hidden_states);
+        hidden_states = add(residual, hidden_states, accelerator());
+        return hidden_states;
     }
 
     friend std::ostream&

--- a/include/metalchat/safetensor.h
+++ b/include/metalchat/safetensor.h
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <istream>
 #include <numeric>
+#include <regex>
 #include <streambuf>
 #include <unordered_map>
 #include <unordered_set>
@@ -155,6 +156,26 @@ public:
       _M_dtype(dtype),
       _M_shape(shape),
       _M_container(container_ptr)
+    {}
+
+    safetensor(
+        const std::string& name,
+        const std::string& dtype,
+        const std::span<std::size_t>& shape,
+        const container_pointer& container_ptr
+    )
+    : safetensor(name, dtype, shape.begin(), shape.end(), container_ptr)
+    {}
+
+    template <std::forward_iterator ForwardIt>
+    safetensor(
+        const std::string& name,
+        const std::string& dtype,
+        ForwardIt first,
+        ForwardIt last,
+        const container_pointer& container_ptr
+    )
+    : safetensor(name, dtype, shape_type(first, last), container_ptr)
     {}
 
     /// Returns a name of the tensor (a complete path as in the original safetensor document).
@@ -809,6 +830,26 @@ public:
     insert(const nn::indirect_layer<Layer>& layer)
     {
         insert(*layer);
+    }
+
+    template <std::forward_iterator ForwardIt>
+    requires std::same_as<typename ForwardIt::value_type, std::pair<std::regex, std::string>>
+    safetensor_document
+    rename(ForwardIt first, ForwardIt last) const
+    {
+        safetensor_document doc;
+        for (auto tensor_it = begin(); tensor_it != end(); ++tensor_it) {
+            auto st = *tensor_it;
+            auto name = st.name();
+
+            for (auto regex_it = first; regex_it != last; ++regex_it) {
+                const auto& [re, replacement] = *regex_it;
+                name = std::regex_replace(name, re, replacement);
+            }
+
+            doc.insert(safetensor(name, st.dtype(), st.sizes(), st.container_ptr()));
+        }
+        return doc;
     }
 
     /// Load tensors from a safetensor document into the layer's registered parameters.


### PR DESCRIPTION
This patch introduces a method to rename layers in a safetensor document that are matching the specified regular expression.