### PR TITLE
Introduce optional normalization layers

### DIFF
--- a/include/metalchat/nn/attention.h
+++ b/include/metalchat/nn/attention.h
@@ -15,6 +15,7 @@
 #include <metalchat/nn/embedding.h>
 #include <metalchat/nn/layer.h>
 #include <metalchat/nn/linear.h>
+#include <metalchat/nn/rmsnorm.h>
 #include <metalchat/tensor/future.h>
 
 
@@ -29,7 +30,12 @@ struct attention_options {
     std::size_t max_seq_len;
     std::size_t max_batch_size;
     float rope_theta;
-    float norm_eps;
+
+    /// Enables RMS-normalization to queries and values, when the value is provided.
+    ///
+    /// \note The layer won't even register RMS-normalization layers, when the value
+    /// is empty.
+    std::optional<float> norm_eps = std::nullopt;
 
     inline std::size_t
     repeats() const
@@ -51,11 +57,15 @@ private:
 
     using BasicLinear = nn::basic_linear<T, Container>;
     using Linear = nn::linear<T, Container>;
+    using RMSNorm = nn::rmsnorm<T, Container>;
 
     polymorphic_layer<BasicLinear> _M_wq;
     polymorphic_layer<BasicLinear> _M_wk;
     polymorphic_layer<BasicLinear> _M_wv;
     polymorphic_layer<BasicLinear> _M_wo;
+
+    indirect_layer<RMSNorm> _M_wq_norm;
+    indirect_layer<RMSNorm> _M_wk_norm;
 
     nn::rope<T> _M_rope;
     nn::attention_options _M_options;
@@ -92,6 +102,18 @@ public:
         _M_wk = register_polymorphic_layer<Linear>("wk");
         _M_wv = register_polymorphic_layer<Linear>("wv");
         _M_wo = register_polymorphic_layer<Linear>("wo");
+
+        if (options.norm_eps) {
+            enable_norm(options.norm_eps.value());
+        }
+    }
+
+    /// Enable RMS-normalization of keys and queries.
+    void
+    enable_norm(float eps)
+    {
+        _M_wq_norm = register_layer<RMSNorm>("q_norm", eps);
+        _M_wk_norm = register_layer<RMSNorm>("k_norm", eps);
     }
 
     template <immutable_tensor3_t<T> Input, cache_t<T> Cache>
@@ -109,8 +131,8 @@ public:
         auto k = _M_wk(input).view({bs, len, n_kv_heads, head_dim});
         auto v = _M_wv(input).view({bs, len, n_kv_heads, head_dim});
 
-        q = _M_rope(q, /*start_pos=*/start_pos);
-        k = _M_rope(k, /*start_pos=*/start_pos);
+        q = _M_rope(_M_wq_norm ? _M_wq_norm(q) : q, /*start_pos=*/start_pos);
+        k = _M_rope(_M_wk_norm ? _M_wk_norm(k) : k, /*start_pos=*/start_pos);
 
         auto [kk, vv, mask] = cache.update(k, v, start_pos);
 

--- a/include/metalchat/nn/layer.h
+++ b/include/metalchat/nn/layer.h
@@ -203,6 +203,13 @@ public:
         return *this;
     }
 
+    /// Checks if the `*this` stores a null layer pointer.
+    explicit
+    operator bool() const noexcept
+    {
+        return _M_value != nullptr;
+    }
+
     /// \copydoc basic_layer::accelerator() const
     const hardware_accelerator&
     accelerator() const;

--- a/include/metalchat/nn/layer_array.h
+++ b/include/metalchat/nn/layer_array.h
@@ -89,6 +89,20 @@ public:
         return *_M_pointers[pos];
     }
 
+    /// Returns a reference to the last element in the container.
+    reference
+    back()
+    {
+        return *_M_pointers.back();
+    }
+
+    /// Returns a const reference to the last element in the container.
+    const_reference
+    back() const
+    {
+        return *_M_pointers.back();
+    }
+
     /// Returns a constant reference to the `pos`-element of the layer array.
     ///
     /// \param pos the position of a layer in the array.

--- a/include/metalchat/nn/llama.h
+++ b/include/metalchat/nn/llama.h
@@ -69,7 +69,7 @@ public:
         _M_embedding = register_polymorphic_layer<Embedding>("tok_embeddings");
         _M_output = register_polymorphic_layer<Linear>("output");
 
-        const auto caching_opts = caching_options{
+        caching_options caching_opts{
             .head_dim = options.head_dim(),
             .n_heads = options.n_heads(),
             .n_kv_heads = options.n_kv_heads(),
@@ -77,17 +77,20 @@ public:
             .max_batch_size = 1
         };
 
-        const auto attention_opts = attention_options{
+        attention_options attention_opts{
             .head_dim = options.head_dim(),
             .n_heads = options.n_heads(),
             .n_kv_heads = options.n_kv_heads(),
             .max_seq_len = options.max_seq_len(),
             .rope_theta = options.rope_theta(),
-            .norm_eps = options.norm_eps()
+            // Llama3 models does not implement RMS-normalization of keys
+            // and queries in the attention layer, so we disable it here.
+            .norm_eps = std::nullopt
         };
 
         for (std::size_t i = 0; i < options.n_layers(); i++) {
             _M_transforms->emplace_back(attention_opts, accelerator);
+            _M_transforms->back().enable_norm(options.norm_eps());
             _M_caches->emplace_back(caching_opts, accelerator);
         }
     }

--- a/include/metalchat/nn/transformer.h
+++ b/include/metalchat/nn/transformer.h
@@ -82,36 +82,60 @@ private:
 
     indirect_layer<Attention> _M_attention;
     indirect_layer<RMSNorm> _M_attention_norm;
+    indirect_layer<RMSNorm> _M_attention_post_norm;
 
     indirect_layer<FeedForward> _M_ff;
     indirect_layer<RMSNorm> _M_ff_norm;
+    indirect_layer<RMSNorm> _M_ff_post_norm;
 
 public:
     using value_type = T;
     using container_type = Container;
 
-    transformer(const attention_options& options, hardware_accelerator accelerator)
+    transformer(const attention_options& options, hardware_accelerator& accelerator)
     : basic_layer(accelerator)
     {
         _M_attention = register_layer<Attention>("attention", options);
-        _M_attention_norm = register_layer<RMSNorm>("attention_norm", options.norm_eps);
         _M_ff = register_layer<FeedForward>("feed_forward");
-        _M_ff_norm = register_layer<RMSNorm>("ffn_norm", options.norm_eps);
+    }
+
+    /// Enable normalization of the attention and feed-forward layers.
+    ///
+    /// The method registers two additional RMS-normalization layers that are executed
+    /// before the attention and feed-forward layers respectively.
+    void
+    enable_norm(float eps)
+    {
+        _M_attention_norm = register_layer<RMSNorm>("attention_norm", eps);
+        _M_ff_norm = register_layer<RMSNorm>("ffn_norm", eps);
+    }
+
+    /// Enable post-normalization of the attention and feed-forward (also called MLP) layers.
+    ///
+    /// The method registers two additional RMS-normalization layers that are executed
+    /// right after the attention and feed-forward layers respectively.
+    void
+    enable_post_norm(float eps)
+    {
+        _M_attention_post_norm = register_layer<RMSNorm>("attention_post_norm", eps);
+        _M_ff_post_norm = register_layer<RMSNorm>("ffn_post_norm", eps);
     }
 
     template <immutable_tensor3_t<T> Input, cache_t<T> Cache>
     auto
     operator()(Input input, Cache& cache, std::size_t start_pos = 0)
     {
-        auto hidden_states = _M_attention_norm(input);
-        hidden_states = _M_attention(hidden_states, cache, start_pos);
-        hidden_states = add(input, hidden_states, accelerator());
+        auto hidden = _M_attention_norm ? _M_attention_norm(input) : input;
+        hidden = _M_attention(hidden, cache, start_pos);
+        hidden = _M_attention_post_norm ? _M_attention_post_norm(hidden) : hidden;
+        hidden = add(input, hidden, accelerator());
 
-        auto residual = hidden_states;
-        hidden_states = _M_ff_norm(hidden_states);
-        hidden_states = _M_ff(hidden_states);
-        hidden_states = add(residual, hidden_states, accelerator());
-        return hidden_states;
+        auto residual = hidden;
+        hidden = _M_ff_norm ? _M_ff_norm(hidden) : hidden;
+        hidden = _M_ff(hidden);
+        hidden = _M_ff_post_norm ? _M_ff_post_norm(hidden) : hidden;
+        hidden = add(residual, hidden, accelerator());
+        return hidden;
     }
 
     friend std::ostream&


### PR DESCRIPTION
This patch introduces optional QK-RMS-normalization in attention layer and optional post-RMS-normalization in transformer layer.