### PR TITLE
Decouple attention mask from cache

### DIFF
--- a/include/metalchat/nn/attention.h
+++ b/include/metalchat/nn/attention.h
@@ -56,11 +56,8 @@ struct attention_options {
 ///
 /// This \ref attention layer implements the original architecture described in the
 /// <a href="https://arxiv.org/abs/1706.03762">Attention Is All You Need paper</a>.
-template <
-    typename T,
-    contiguous_container Container,
-    cache_t<T> Cache = sink_cache<T>
-> class attention : public basic_layer {
+template <typename T, contiguous_container Container, cache_t<T> Cache = sink_cache<T>>
+class attention : public basic_layer {
 private:
     static constexpr std::size_t input_size = 4;
 

--- a/include/metalchat/nn/attention.h
+++ b/include/metalchat/nn/attention.h
@@ -23,10 +23,15 @@ namespace nn {
 
 
 struct attention_options {
+    /// Per-attention head embedding dimension.
     std::size_t head_dim;
+    /// Number of query heads.
     std::size_t n_heads;
+    /// Number of key and value heads.
     std::size_t n_kv_heads;
+    /// Maximum sequence length model will be run with.
     std::size_t max_seq_len;
+    /// Batch size the model will be run with.
     std::size_t max_batch_size;
     float rope_theta;
 
@@ -51,27 +56,33 @@ struct attention_options {
 ///
 /// This \ref attention layer implements the original architecture described in the
 /// <a href="https://arxiv.org/abs/1706.03762">Attention Is All You Need paper</a>.
-template <typename T, contiguous_container Container> class attention : public basic_layer {
+template <
+    typename T,
+    contiguous_container Container,
+    cache_t<T> Cache = sink_cache<T>
+> class attention : public basic_layer {
 private:
     static constexpr std::size_t input_size = 4;
 
     using BasicLinear = nn::basic_linear<T, Container>;
     using Linear = nn::linear<T, Container>;
     using RMSNorm = nn::rmsnorm<T, Container>;
+    using RotaryPositionalEmbedding = nn::rope<T>;
 
     polymorphic_layer<BasicLinear> _M_wq;
     polymorphic_layer<BasicLinear> _M_wk;
     polymorphic_layer<BasicLinear> _M_wv;
     polymorphic_layer<BasicLinear> _M_wo;
 
+    indirect_layer<RotaryPositionalEmbedding> _M_rope;
     indirect_layer<RMSNorm> _M_wq_norm;
     indirect_layer<RMSNorm> _M_wk_norm;
+    indirect_layer<Cache> _M_cache;
 
-    nn::rope<T> _M_rope;
     nn::attention_options _M_options;
-    T _M_scale;
-
     kernel::clone<T> _M_clone;
+
+    T _M_scale;
 
     template <immutable_tensor_t<T> Input>
     auto
@@ -95,13 +106,23 @@ public:
     : basic_layer(accelerator),
       _M_rope(options.head_dim, options.max_seq_len, /*thetha=*/options.rope_theta, accelerator),
       _M_options(options),
-      _M_scale(options.scale),
-      _M_clone(accelerator)
+      _M_clone(accelerator),
+      _M_scale(options.scale)
     {
         _M_wq = register_polymorphic_layer<Linear>("wq");
         _M_wk = register_polymorphic_layer<Linear>("wk");
         _M_wv = register_polymorphic_layer<Linear>("wv");
         _M_wo = register_polymorphic_layer<Linear>("wo");
+
+        caching_options cache_options{
+            .head_dim = options.head_dim,
+            .n_heads = options.n_heads,
+            .n_kv_heads = options.n_kv_heads,
+            .max_seq_len = options.max_seq_len,
+            .max_batch_size = options.max_batch_size,
+        };
+
+        _M_cache = register_layer<Cache>("cache", cache_options);
 
         if (options.norm_eps) {
             enable_norm(options.norm_eps.value());
@@ -116,9 +137,13 @@ public:
         _M_wk_norm = register_layer<RMSNorm>("k_norm", eps);
     }
 
-    template <immutable_tensor3_t<T> Input, cache_t<T> Cache>
+    /// Compute multi-head attention of the input sequence.
+    ///
+    /// \param input an input embedding.
+    /// \param mask if specified, a 2-dim mask preventing attention to certain positions.
+    template <immutable_tensor3_t<T> Input, immutable_tensor2_t<T> Mask>
     auto
-    operator()(Input input, Cache& cache, std::size_t start_pos = 0)
+    operator()(Input input, std::optional<Mask> mask = std::nullopt, std::size_t start_pos = 0)
     {
         int bs = input.size(0);
         int len = input.size(1);
@@ -134,7 +159,7 @@ public:
         q = _M_rope(_M_wq_norm ? _M_wq_norm(q) : q, /*start_pos=*/start_pos);
         k = _M_rope(_M_wk_norm ? _M_wk_norm(k) : k, /*start_pos=*/start_pos);
 
-        auto [kk, vv, mask] = cache.update(k, v, start_pos);
+        auto [kk, vv] = _M_cache->update(k, v, start_pos);
 
         auto repeat_kv = [&]<immutable_tensor4_t<T> Tensor>(Tensor&& t) -> auto {
             int slen = t.size(1);

--- a/include/metalchat/nn/cache.h
+++ b/include/metalchat/nn/cache.h
@@ -151,7 +151,6 @@ public:
     }
 
 private:
-
     auto
     alloc(const caching_options& options)
     {

--- a/include/metalchat/nn/cache.h
+++ b/include/metalchat/nn/cache.h
@@ -28,10 +28,6 @@ template <typename T> struct caching_result {
 
     /// A future tensor that will contain a result of values caching query.
     future_tensor<T, 4> values;
-
-    /// An optional future tensor that will contain a result of additive causal mask creation.
-    /// This mask is created only when the length of keys (or values) is larger than `1`.
-    std::optional<future_tensor<T, 2>> mask;
 };
 
 
@@ -101,7 +97,6 @@ template <typename T> class sink_cache : public basic_layer {
 public:
     using value_type = T;
     using input_tensor = future_tensor<T, 4>;
-    using mask_tensor = std::optional<future_tensor<T, 2>>;
 
     /// Constructs a new instance of the sink cache.
     ///
@@ -109,7 +104,7 @@ public:
     /// \param options caching options for the KV cache.
     /// \param accelerator a hardware accelerator instance.
     sink_cache(
-        std::size_t pre_len, const caching_options& options, hardware_accelerator accelerator
+        std::size_t pre_len, const caching_options& options, hardware_accelerator& accelerator
     )
     : basic_layer(accelerator),
       _M_clone(accelerator),
@@ -152,31 +147,10 @@ public:
         _M_vals = cache_vals;
         update_parameters();
 
-        auto len = keys.size(1);
-        auto mask_len = k.size(1);
-        auto mask = create_additive_causal_mask(len, mask_len);
-
-        return caching_result{k, v, mask};
+        return caching_result{k, v};
     }
 
 private:
-    auto
-    create_additive_causal_mask(std::size_t len, std::size_t mask_len) const
-    {
-        mask_tensor mask;
-
-        if (len > 1) {
-            const T infinity = T(std::numeric_limits<float>::infinity());
-
-            auto alloc = accelerator().get_allocator();
-            auto m = full<T>({len, mask_len}, -infinity, alloc);
-
-            triu(m.narrow(1, mask_len - len, len));
-            mask = std::make_optional(std::move(m));
-        }
-
-        return mask;
-    }
 
     auto
     alloc(const caching_options& options)

--- a/include/metalchat/nn/embedding.h
+++ b/include/metalchat/nn/embedding.h
@@ -43,6 +43,10 @@ public:
 };
 
 
+/// A simple lookup table that stores embeddings of a fixed dictionary and size.
+///
+/// This module is often used to store word embeddings and retrieve them using indices. The input
+/// to the module is a list of indices, and the output is the corresponding word embeddings.
 template <typename T, contiguous_container Container = hardware_memory_container<T>>
 class embedding : public basic_embedding<T, Container> {
     using _Base = basic_embedding<T, Container>;
@@ -159,7 +163,7 @@ private:
     }
 
 public:
-    rope(std::size_t dim, std::size_t max_seq_len, float theta, hardware_accelerator accelerator)
+    rope(std::size_t dim, std::size_t max_seq_len, float theta, hardware_accelerator& accelerator)
     : basic_layer(accelerator),
       _M_start_pos(0),
       _M_dim(dim),

--- a/include/metalchat/nn/llama.h
+++ b/include/metalchat/nn/llama.h
@@ -13,7 +13,6 @@
 #include <metalchat/container.h>
 #include <metalchat/dtype.h>
 #include <metalchat/functional.h>
-#include <metalchat/nn/cache.h>
 #include <metalchat/nn/embedding.h>
 #include <metalchat/nn/layer.h>
 #include <metalchat/nn/options.h>
@@ -29,15 +28,11 @@ namespace nn {
 /// Llama 3 is an auto-regressive language model that uses an optimized transformer architecture.
 /// The tuned versions use supervised fine-tuning (SFT) and reinforcement learning with human
 /// feedback (RLHF) to align with human preferences for helpfulness and safety.
-template <
-    typename T,
-    contiguous_container Container = hardware_memory_container<T>,
-    cache_t<T> Cache = sink_cache<T>>
+template <typename T, contiguous_container Container = hardware_memory_container<T>>
 class llama3 : public basic_layer {
 private:
     using Transformer = nn::transformer<T, Container>;
     using TransformerArray = layer_array<Transformer>;
-    using CacheArray = layer_array<Cache>;
     using BasicEmbedding = nn::basic_embedding<T, Container>;
     using Embedding = nn::embedding<T, Container>;
     using RMSNorm = nn::rmsnorm<T, Container>;
@@ -49,40 +44,32 @@ private:
 
     indirect_layer<RMSNorm> _M_norm;
     indirect_layer<TransformerArray> _M_transforms;
-    indirect_layer<CacheArray> _M_caches;
+
+    llama3_options _M_options;
 
 public:
     using index_type = int32_t;
     using value_type = T;
     using container_type = Container;
-    using cache_type = Cache;
     using tensor_type = future_tensor<index_type, 2>;
 
     /// Constructs a new Llama3 model with uninitialized weights with the given options.
     llama3(const llama3_options& options, hardware_accelerator& accelerator)
-        requires cache_constructible<Cache>
-    : basic_layer(accelerator)
+    : basic_layer(accelerator),
+      _M_options(options)
     {
         _M_norm = register_layer<RMSNorm>("norm", options.norm_eps());
         _M_transforms = register_layer<TransformerArray>("layers");
-        _M_caches = register_layer<CacheArray>("caches");
 
         _M_embedding = register_polymorphic_layer<Embedding>("tok_embeddings");
         _M_output = register_polymorphic_layer<Linear>("output");
-
-        caching_options caching_opts{
-            .head_dim = options.head_dim(),
-            .n_heads = options.n_heads(),
-            .n_kv_heads = options.n_kv_heads(),
-            .max_seq_len = options.max_seq_len(),
-            .max_batch_size = 1
-        };
 
         attention_options attention_opts{
             .head_dim = options.head_dim(),
             .n_heads = options.n_heads(),
             .n_kv_heads = options.n_kv_heads(),
             .max_seq_len = options.max_seq_len(),
+            .max_batch_size = 1,
             .rope_theta = options.rope_theta(),
             .scale = 1.0f / std::sqrt(float(options.head_dim())),
             // Llama3 models does not implement RMS-normalization of keys
@@ -93,7 +80,6 @@ public:
         for (std::size_t i = 0; i < options.n_layers(); i++) {
             _M_transforms->emplace_back(attention_opts, accelerator);
             _M_transforms->back().enable_norm(options.norm_eps());
-            _M_caches->emplace_back(caching_opts, accelerator);
         }
     }
 
@@ -110,19 +96,39 @@ public:
     {
         auto x = _M_embedding(input);
 
+        auto len = x.size(1);
+        auto end_pos = std::min(start_pos + len, _M_options.max_seq_len());
+        auto mask = create_additive_causal_mask(len, end_pos);
+
         for (std::size_t i = 0; i < _M_transforms->size(); i++) {
             auto& transform = _M_transforms->at(i);
-            auto& cache = _M_caches->at(i);
-
-            x = transform(x, cache, start_pos);
+            x = transform(x, mask, start_pos);
         }
 
         auto output = _M_norm(x);
 
-        auto len = output.size(1);
+        len = output.size(1);
         output = output.narrow(1, len - 1, 1);
 
         return _M_output(output);
+    }
+
+    auto
+    create_additive_causal_mask(std::size_t len, std::size_t end_pos) const
+    {
+        std::optional<future_tensor<T, 2>> mask;
+
+        if (len > 1) {
+            const T infinity = T(std::numeric_limits<float>::infinity());
+
+            auto alloc = accelerator().get_allocator();
+            auto m = full<T>({len, end_pos}, -infinity, alloc);
+
+            triu(m.narrow(1, end_pos - len, len));
+            mask = std::make_optional(std::move(m));
+        }
+
+        return mask;
     }
 };
 

--- a/include/metalchat/nn/transformer.h
+++ b/include/metalchat/nn/transformer.h
@@ -10,7 +10,6 @@
 #include <metalchat/container.h>
 #include <metalchat/functional.h>
 #include <metalchat/nn/attention.h>
-#include <metalchat/nn/cache.h>
 #include <metalchat/nn/layer.h>
 #include <metalchat/nn/linear.h>
 #include <metalchat/nn/rmsnorm.h>
@@ -121,12 +120,12 @@ public:
         _M_ff_post_norm = register_layer<RMSNorm>("ffn_post_norm", eps);
     }
 
-    template <immutable_tensor3_t<T> Input, cache_t<T> Cache>
+    template <immutable_tensor3_t<T> Input, immutable_tensor2_t<T> Mask>
     auto
-    operator()(Input input, Cache& cache, std::size_t start_pos = 0)
+    operator()(Input input, std::optional<Mask> mask = std::nullopt, std::size_t start_pos = 0)
     {
         auto hidden = _M_attention_norm ? _M_attention_norm(input) : input;
-        hidden = _M_attention(hidden, cache, start_pos);
+        hidden = _M_attention(hidden, mask, start_pos);
         hidden = _M_attention_post_norm ? _M_attention_post_norm(hidden) : hidden;
         hidden = add(input, hidden, accelerator());
 


### PR DESCRIPTION
This patch decouples attention mask from the cache layer and moves it to the attention layer itself. Now mask is passed through the transformer layer by a Llama3 model.