### PR TITLE
Introduce `diagonal` parameter to the `triu` method

### DIFF
--- a/include/metalchat/functional/primitive.h
+++ b/include/metalchat/functional/primitive.h
@@ -222,22 +222,33 @@ multinomial(Tensor t, std::size_t sample_size, hardware_accelerator& gpu)
 }
 
 
-template <typename T, contiguous_container Container>
+/// Sets elements of the lower triangular part of a tensor to 0, the upper
+/// triangular part of the result is retained.
+///
+/// The method modified the data of a tensor in-place.
+///
+/// \param input the input tensor.
+/// \param diagonal the diagonal to consider.
+template <immutable_tensor Tensor>
 void
-triu(tensor<T, 2, Container>& t)
+triu(Tensor& input, int diagonal = 0)
 {
-    for (std::size_t i = 0; i < t.size(0); i++) {
-        for (std::size_t j = 0; j <= i && j < t.size(1); j++) {
-            t[i][j] = T(0);
+    std::size_t first = diagonal > 0 ? 0 : 1 - diagonal;
+    std::size_t last = diagonal < 0 ? 1 : diagonal;
+
+    for (std::size_t i = first; i < input.size(0); i++, last++) {
+        for (std::size_t j = 0; j < last && j < input.size(1); j++) {
+            input[i][j] = typename Tensor::value_type(0);
         }
     }
 }
 
-template <typename T, contiguous_container Container>
+
+template <immutable_tensor Tensor>
 void
-triu(tensor<T, 2, Container>&& t)
+triu(Tensor&& input, int diagonal = 0)
 {
-    triu(t);
+    triu(input, diagonal);
 }
 
 

--- a/include/metalchat/nn/llama.h
+++ b/include/metalchat/nn/llama.h
@@ -124,7 +124,7 @@ public:
             auto alloc = accelerator().get_allocator();
             auto m = full<T>({len, end_pos}, -infinity, alloc);
 
-            triu(m.narrow(1, end_pos - len, len));
+            triu(m.narrow(1, end_pos - len, len), /*diagonal=*/1);
             mask = std::make_optional(std::move(m));
         }
 

--- a/include/metalchat/tensor/format.h
+++ b/include/metalchat/tensor/format.h
@@ -19,6 +19,7 @@ namespace fmt {
 
 constexpr std::size_t precision = 3;
 constexpr std::size_t edgeitems = 4;
+constexpr std::size_t maxitems = 16;
 
 
 struct comma {
@@ -65,7 +66,7 @@ struct tensor_format : public basic_tensor_format<T, N, Container> {
     operator<<(std::ostream& os, const tensor_format<T, N, Container>& tf)
     {
         auto size = tf.t.size(0);
-        auto max_size = fmt::edgeitems * 2 + 1;
+        auto max_size = std::max(fmt::maxitems, fmt::edgeitems * 2 + 1);
 
         using format_type = tensor_format<T, N - 1, Container>;
 
@@ -108,7 +109,7 @@ struct tensor_format<T, 1, Container> : public basic_tensor_format<T, 1, Contain
     operator<<(std::ostream& os, const tensor_format<T, 1, Container>& tf)
     {
         auto size = tf.t.size(0);
-        auto max_size = fmt::edgeitems * 2 + 1;
+        auto max_size = std::max(fmt::maxitems, fmt::edgeitems * 2 + 1);
 
         using format_type = tensor_format<T, 0, Container>;
 

--- a/test/test_functional.cc
+++ b/test/test_functional.cc
@@ -17,7 +17,7 @@ TEST_CASE("Test repeat interleave", "[functional::repeat_interleave]")
 {
     auto original = shared_tensor(rand<float>({1, 6, 8, 64}));
 
-    metalchat::hardware_accelerator gpu0;
+    hardware_accelerator gpu0;
     auto output = repeat_interleave(original, 4, /*dim=*/2, gpu0).get();
 
     REQUIRE(output.dim() == 5);
@@ -38,4 +38,11 @@ TEST_CASE("Test repeat interleave", "[functional::repeat_interleave]")
             }
         }
     }
+}
+
+
+TEST_CASE("Test triu (diagonal=0)", "[functional::triu]")
+{
+    auto T = full({10, 10}, 1);
+    triu(T, /*diagonal=*/0);
 }

--- a/test/test_triu.cc
+++ b/test/test_triu.cc
@@ -13,10 +13,10 @@
 using namespace metalchat;
 
 
-TEST_CASE("Tensor", "triu")
+TEST_CASE("Tensor triu (diagonal=1)", "[functional::triu]")
 {
     auto t = full<float>({10, 10}, 3.0f);
-    triu<float>(t);
+    triu(t, /*diagonal=*/1);
 
     for (std::size_t i = 0; i < t.size(0); i++) {
         for (std::size_t j = 0; j < t.size(1); j++) {
@@ -25,6 +25,45 @@ TEST_CASE("Tensor", "triu")
             } else {
                 REQUIRE(t[i][j] == 0.0f);
             }
+        }
+    }
+}
+
+
+TEST_CASE("Tensor triu (diagonal=4)", "[functional::triu]")
+{
+    auto t = full<float>({5, 10}, 3.0f);
+    triu(t, /*diagonal=*/4);
+
+    std::size_t last = 4;
+    for (std::size_t i = 0; i < t.size(0); i++, last++) {
+        for (std::size_t j = 0; j < t.size(1); j++) {
+            if (j >= last) {
+                REQUIRE(t[i][j] == 3.0f);
+            } else {
+                REQUIRE(t[i][j] == 0.0f);
+            }
+        }
+    }
+}
+
+
+TEST_CASE("Tensor triu (diagonal=-4)", "[functional::triu]")
+{
+    auto t = full<float>({10, 10}, 3.0f);
+    triu(t, /*diagonal=*/-4);
+
+    std::size_t last = 1;
+    for (std::size_t i = 0; i < t.size(0); i++) {
+        for (std::size_t j = 0; j < t.size(1); j++) {
+            if (i > 4 && j < last) {
+                REQUIRE(t[i][j] == 0.0f);
+            } else {
+                REQUIRE(t[i][j] == 3.0f);
+            }
+        }
+        if (i > 4) {
+            last++;
         }
     }
 }


### PR DESCRIPTION
This patch adds an optional `diagonal` parameter to the `triu` method.