### PR TITLE
Introduce a `mu` parameter for the RMS normalization layer

### DIFF
--- a/include/metalchat/kernel/rmsnorm.h
+++ b/include/metalchat/kernel/rmsnorm.h
@@ -15,6 +15,7 @@ namespace metalchat {
 namespace kernel {
 
 
+/// Applies Root Mean Square Layer Normalization.
 template <typename T> class rmsnorm {
 private:
     basic_kernel _M_kernel;
@@ -26,7 +27,7 @@ public:
 
     template <immutable_tensor_t<T> Input, immutable_tensor1_t<T> Weight>
     auto
-    operator()(Input input, Weight weight, const float eps = 1e-5)
+    operator()(Input input, Weight weight, const float eps = 1e-5f, const float mu = 0.0f)
     {
         auto dim_size = input.sizes().back();
         auto num_rows = input.numel() / dim_size;
@@ -45,7 +46,7 @@ public:
 
         auto task = kernel_task(_M_kernel, grid, thread);
         auto task_future = task.bind_front(
-            output_view, input_view, expected_weight, scalar<float>(eps),
+            output_view, input_view, expected_weight, scalar<float>(eps), scalar<float>(mu),
             scalar<uint32_t>(block_size)
         );
 

--- a/include/metalchat/nn/attention.h
+++ b/include/metalchat/nn/attention.h
@@ -44,6 +44,12 @@ struct attention_options {
     /// is empty.
     std::optional<float> norm_eps = std::nullopt;
 
+    /// When RMS is distributed as residuals from a mean, then this parameter is used
+    /// to restore the weight of RMS to the original state.
+    ///
+    /// \note This option has no effect on attention normalization, when `norm_eps` is unset.
+    std::optional<float> norm_mu = std::nullopt;
+
     inline std::size_t
     repeats() const
     {
@@ -122,16 +128,16 @@ public:
         _M_cache = register_layer<Cache>("cache", cache_options);
 
         if (options.norm_eps) {
-            enable_norm(options.norm_eps.value());
+            enable_norm(options.norm_eps.value(), options.norm_mu.value_or(0.0f));
         }
     }
 
     /// Enable RMS-normalization of keys and queries.
     void
-    enable_norm(float eps)
+    enable_norm(float eps, float mu)
     {
-        _M_wq_norm = register_layer<RMSNorm>("q_norm", eps);
-        _M_wk_norm = register_layer<RMSNorm>("k_norm", eps);
+        _M_wq_norm = register_layer<RMSNorm>("q_norm", eps, mu);
+        _M_wk_norm = register_layer<RMSNorm>("k_norm", eps, mu);
     }
 
     /// Compute multi-head attention of the input sequence.

--- a/include/metalchat/nn/gemma.h
+++ b/include/metalchat/nn/gemma.h
@@ -71,7 +71,7 @@ public:
     : basic_layer(accelerator),
       _M_options(options)
     {
-        _M_norm = register_layer<RMSNorm>("norm", options.norm_eps);
+        _M_norm = register_layer<RMSNorm>("norm", options.norm_eps, /*mu=*/1.0f);
         _M_transforms = register_layer<TransformerArray>("layers");
         _M_embedding = register_layer<Embedding>("tok_embeddings");
         _M_output = register_layer<Linear>("output");
@@ -86,13 +86,14 @@ public:
                 .max_seq_len = options.max_seq_len,
                 .max_batch_size = 1,
                 .rope_theta = rope_theta,
-                .scale = float(1.0 / std::sqrt(double(options.attn_scale))),
+                .scale = 1.0f / std::sqrt(options.attn_scale),
                 .norm_eps = options.norm_eps,
+                .norm_mu = 1.0f
             };
 
             _M_transforms->emplace_back(attention_opts, accelerator);
-            _M_transforms->back().enable_norm(options.norm_eps);
-            _M_transforms->back().enable_post_norm(options.norm_eps);
+            _M_transforms->back().enable_norm(options.norm_eps, /*mu=*/1.0f);
+            _M_transforms->back().enable_post_norm(options.norm_eps, /*mu=*/1.0f);
         }
     }
 

--- a/include/metalchat/nn/llama.h
+++ b/include/metalchat/nn/llama.h
@@ -86,7 +86,8 @@ public:
             .scale = 1.0f / std::sqrt(float(options.head_dim)),
             // Llama3 models does not implement RMS-normalization of keys
             // and queries in the attention layer, so we disable it here.
-            .norm_eps = std::nullopt
+            .norm_eps = std::nullopt,
+            .norm_mu = std::nullopt,
         };
 
         for (std::size_t i = 0; i < options.n_layers; i++) {

--- a/include/metalchat/nn/rmsnorm.h
+++ b/include/metalchat/nn/rmsnorm.h
@@ -22,28 +22,37 @@ public:
     using weight_type = tensor<T, 1, Container>;
     using weight_pointer = shared_tensor_ptr<weight_type>;
 
-    rmsnorm(weight_type&& weight, float eps, hardware_accelerator accelerator)
+    rmsnorm(weight_type&& weight, float eps, float mu, hardware_accelerator& accelerator)
     : basic_layer(accelerator),
       _M_weight(std::move(weight)),
       _M_norm(accelerator),
-      _M_eps(eps)
+      _M_eps(eps),
+      _M_mu(mu)
     {
         register_parameter("weight", _M_weight);
     }
 
-    rmsnorm(std::size_t normalized_size, float eps, hardware_accelerator accelerator)
-    : rmsnorm(empty<T>({normalized_size}, accelerator), eps, accelerator)
+    rmsnorm(std::size_t normalized_size, float eps, float mu, hardware_accelerator& accelerator)
+    : rmsnorm(empty<T>({normalized_size}, accelerator), eps, mu, accelerator)
     {}
 
-    rmsnorm(float eps, hardware_accelerator accelerator)
-    : rmsnorm(weight_type(), eps, accelerator)
+    rmsnorm(std::size_t normalized_size, float eps, hardware_accelerator& accelerator)
+    : rmsnorm(normalized_size, eps, 0.0f, accelerator)
+    {}
+
+    rmsnorm(float eps, float mu, hardware_accelerator& accelerator)
+    : rmsnorm(weight_type(), eps, mu, accelerator)
+    {}
+
+    rmsnorm(float eps, hardware_accelerator& accelerator)
+    : rmsnorm(eps, 0.0f, accelerator)
     {}
 
     template <immutable_tensor_t<T> Input>
     auto
     operator()(Input input)
     {
-        return _M_norm(input, _M_weight, _M_eps);
+        return _M_norm(input, _M_weight, _M_eps, _M_mu);
     }
 
     friend std::ostream&
@@ -58,6 +67,7 @@ private:
     weight_pointer _M_weight;
     kernel::rmsnorm<T> _M_norm;
     float _M_eps;
+    float _M_mu;
 };
 
 

--- a/include/metalchat/nn/transformer.h
+++ b/include/metalchat/nn/transformer.h
@@ -102,10 +102,10 @@ public:
     /// The method registers two additional RMS-normalization layers that are executed
     /// before the attention and feed-forward layers respectively.
     void
-    enable_norm(float eps)
+    enable_norm(float eps, float mu = 0.0f)
     {
-        _M_attention_norm = register_layer<RMSNorm>("attention_norm", eps);
-        _M_ff_norm = register_layer<RMSNorm>("ffn_norm", eps);
+        _M_attention_norm = register_layer<RMSNorm>("attention_norm", eps, mu);
+        _M_ff_norm = register_layer<RMSNorm>("ffn_norm", eps, mu);
     }
 
     /// Enable post-normalization of the attention and feed-forward (also called MLP) layers.
@@ -113,10 +113,10 @@ public:
     /// The method registers two additional RMS-normalization layers that are executed
     /// right after the attention and feed-forward layers respectively.
     void
-    enable_post_norm(float eps)
+    enable_post_norm(float eps, float mu = 0.0f)
     {
-        _M_attention_post_norm = register_layer<RMSNorm>("attention_post_norm", eps);
-        _M_ff_post_norm = register_layer<RMSNorm>("ffn_post_norm", eps);
+        _M_attention_post_norm = register_layer<RMSNorm>("attention_post_norm", eps, mu);
+        _M_ff_post_norm = register_layer<RMSNorm>("ffn_post_norm", eps, mu);
     }
 
     template <immutable_tensor3_t<T> Input, immutable_tensor2_t<T> Mask>

--- a/kernel/activation.metal
+++ b/kernel/activation.metal
@@ -56,22 +56,24 @@ gelu(
     uint2 threadgroup_size [[threads_per_threadgroup]]
 )
 {
+    constexpr float gelu_limit = 4.0f;
+    constexpr float gelu_coeff = 0.044714f;
+
     const uint row_size = params.input.size(0);
     const uint dim_size = params.input.size(1);
     const uint i = gid.y * threadgroup_size.y + tid.y;
     const uint k = gid.x * threadgroup_size.x + tid.x;
 
-    constexpr T limit = T(4);
-
     if (i < row_size && k < dim_size) {
         const T x = params.input.at(i, k);
-        if (x >= limit) {
+
+        if (x >= gelu_limit) {
             params.output.at(i, k) = x;
-        } else if (x <= -limit) {
+        } else if (x <= -gelu_limit) {
             params.output.at(i, k) = T(0);
         } else {
-            const float sqrt_2_pi = metal::sqrt(2.0 / M_PI_F);
-            const float xh = x + 0.044715f * metal::pow(x, 3);
+            const float sqrt_2_pi = metal::fast::sqrt(2.0 / M_PI_F);
+            const float xh = x + gelu_coeff * metal::fast::pow(x, 3);
 
             params.output.at(i, k) = T(x * 0.5 * (1.0 + metal::tanh(sqrt_2_pi * xh)));
         }

--- a/kernel/rmsnorm.metal
+++ b/kernel/rmsnorm.metal
@@ -20,6 +20,7 @@ template <typename T> struct __rmsnorm_parameters {
     constant tensor_layout<1>& weight_layout;
     device const T* weight;
     constant float& eps;
+    constant float& mu;
     constant uint& block_size;
 };
 
@@ -60,7 +61,9 @@ rmsnorm(
     threadgroup float threadgroup_sum[SIMD_SIZE];
 
     //  Initialize shared memory
-    threadgroup_sum[tid] = 0;
+    if (simd_gid == 0) {
+        threadgroup_sum[simd_tid] = 0;
+    }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
     // Write simd accumulations into shared memory
@@ -81,7 +84,7 @@ rmsnorm(
 
     // Write the outputs
     for (uint j = begin; j < end && j < dim_size; j++) {
-        out.at(i, j) = w.at(j) * T(in.at(i, j) * threadgroup_inv_mean[0]);
+        out.at(i, j) = T((w.at(j) + params.mu) * in.at(i, j) * threadgroup_inv_mean[0]);
     }
 }
 

--- a/test/test_kernel_activation.cc
+++ b/test/test_kernel_activation.cc
@@ -45,11 +45,11 @@ TEST_CASE("GELU nan result", "[kernel::gelu]")
     metalchat::hardware_accelerator gpu0;
     kernel::gelu<bf16> gelu(gpu0);
 
-    auto input = shared_tensor(full<bf16>({1, 10}, bf16(9.0)));
+    auto input = shared_tensor(full<bf16>({1, 10}, bf16(12.0)));
     auto output = gelu(input).get();
 
     for (std::size_t i = 0; i < output.size(1); i++) {
-        REQUIRE_THAT((output[0, i]), Catch::Matchers::WithinAbs(9.0, 0.00001));
+        REQUIRE_THAT((output[0, i]), Catch::Matchers::WithinAbs(12.0, 0.00001));
     }
 }
 


### PR DESCRIPTION
This patch adds an optional parameter for the RMS normalization layer.