### PR TITLE
Use precise tanh in gelu kernel

### DIFF
--- a/include/metalchat/nn/gemma.h
+++ b/include/metalchat/nn/gemma.h
@@ -23,6 +23,7 @@ namespace nn {
 
 struct gemma3_options {
     std::size_t head_dim = 0;
+    std::size_t hidden_dim = 0;
     std::size_t n_heads = 0;
     std::size_t n_kv_heads = 0;
     std::size_t n_layers = 0;
@@ -102,7 +103,7 @@ public:
     operator()(Input input, std::size_t start_pos = 0)
     {
         auto x = _M_embedding(input);
-        x = mul(x, T(std::sqrt(640.0f)), accelerator());
+        x = mul(x, T(std::sqrt(_M_options.hidden_dim)), accelerator());
 
         auto len = x.size(1);
         auto end_pos = std::min(start_pos + len, _M_options.max_seq_len);

--- a/include/metalchat/nn/transformer.h
+++ b/include/metalchat/nn/transformer.h
@@ -54,8 +54,8 @@ public:
     auto
     operator()(Input input)
     {
-        auto input2 = _M_w3(input);
         auto input1 = _M_activation(_M_w1(input));
+        auto input2 = _M_w3(input);
         return _M_w2(hadamard(input1, input2, accelerator()));
     }
 

--- a/kernel/activation.metal
+++ b/kernel/activation.metal
@@ -69,7 +69,7 @@ gelu(
         const float x3 = x * x * x;
         const float inner = beta * (x + kappa * x3);
 
-        params.output.at(i, k) = T(0.5f * x * (1 + metal::precise::tanh(inner)));
+        params.output.at(i, k) = T(0.5f * x * (1.0f + metal::precise::tanh(inner)));
     }
 }
 

--- a/kernel/activation.metal
+++ b/kernel/activation.metal
@@ -56,8 +56,8 @@ gelu(
     uint2 threadgroup_size [[threads_per_threadgroup]]
 )
 {
-    constexpr float gelu_limit = 4.0f;
-    constexpr float gelu_coeff = 0.044714f;
+    constexpr float beta = M_SQRT2_F * M_2_SQRTPI_F * 0.5f;
+    constexpr float kappa = 0.044715f;
 
     const uint row_size = params.input.size(0);
     const uint dim_size = params.input.size(1);
@@ -65,18 +65,11 @@ gelu(
     const uint k = gid.x * threadgroup_size.x + tid.x;
 
     if (i < row_size && k < dim_size) {
-        const T x = params.input.at(i, k);
+        const float x = params.input.at(i, k);
+        const float x3 = x * x * x;
+        const float inner = beta * (x + kappa * x3);
 
-        if (x >= gelu_limit) {
-            params.output.at(i, k) = x;
-        } else if (x <= -gelu_limit) {
-            params.output.at(i, k) = T(0);
-        } else {
-            const float sqrt_2_pi = metal::fast::sqrt(2.0 / M_PI_F);
-            const float xh = x + gelu_coeff * metal::fast::pow(x, 3);
-
-            params.output.at(i, k) = T(x * 0.5 * (1.0 + metal::tanh(sqrt_2_pi * xh)));
-        }
+        params.output.at(i, k) = T(0.5f * x * (1 + metal::precise::tanh(inner)));
     }
 }
 

--- a/src/gemma.cc
+++ b/src/gemma.cc
@@ -24,6 +24,7 @@ gemma3_options_serializer::load(std::istream& is) const
 
     return nn::gemma3_options{
         .head_dim = options.head_dim,
+        .hidden_dim = options.hidden_size,
         .n_heads = options.num_attention_heads,
         .n_kv_heads = options.num_key_value_heads,
         .n_layers = options.num_hidden_layers,
@@ -45,6 +46,7 @@ gemma3_options_serializer::save(std::ostream& os, const nn::gemma3_options& opti
 
     auto hf_options = options_type{
         .head_dim = options.head_dim,
+        .hidden_size = options.hidden_dim,
         .num_hidden_layers = options.n_layers,
         .num_attention_heads = options.n_heads,
         .num_key_value_heads = options.n_kv_heads,

--- a/src/huggingface.h
+++ b/src/huggingface.h
@@ -33,6 +33,7 @@ struct llama3_options {
 /// Partial view of the HuggingFace's Gemma3 configuration.
 struct gemma3_options {
     std::size_t head_dim = 0;
+    std::size_t hidden_size = 0;
     std::size_t num_hidden_layers = 0;
     std::size_t num_attention_heads = 0;
     std::size_t num_key_value_heads = 0;
@@ -131,8 +132,9 @@ JSONCONS_ALL_MEMBER_TRAITS(
 
 JSONCONS_N_MEMBER_TRAITS(
     hf::gemma3_options,
-    9,
+    10,
     head_dim,
+    hidden_size,
     num_hidden_layers,
     num_attention_heads,
     num_key_value_heads,


### PR DESCRIPTION
This patch replaces fast tanh approximation in gelu kernel computation.