### PR TITLE
Change RoPE implementation

### DIFF
--- a/include/metalchat/huggingface/llama.h
+++ b/include/metalchat/huggingface/llama.h
@@ -62,7 +62,6 @@ public:
         auto doc = adapt(document);
         doc.load(layer);
 
-        adapt(layer);
         return layer;
     }
 
@@ -104,41 +103,6 @@ public:
         doc.insert("output.weight", "tok_embeddings.weight");
 
         return doc;
-    }
-
-    /// Perform permutation of the attention heads within Wq and Wk layers so that the order
-    /// of elements as in the Meta's reference implementation.
-    ///
-    /// The Meta's reference implementation of attention layer differs from HuggingFace's
-    /// implementation. Specifically, the attention heads are permuted. This layer adaptor
-    /// performs a permutation to the shape expected in the reference implementation.
-    ///
-    /// The side-effect of this adaptor is increase of a memory required to launch the model,
-    /// since after permutations weight tensors become discontiguous and their usage requires
-    /// copying them.
-    ///
-    /// \param layer a layer to adapt to the reference implementation.
-    void
-    adapt(value_type& layer)
-    {
-        const std::vector<std::pair<std::regex, std::size_t>> permutations = {
-            {std::regex(R"(layers\.(\d+)\.attention\.wk\.weight)"), _M_options.n_kv_heads},
-            {std::regex(R"(layers\.(\d+)\.attention\.wq\.weight)"), _M_options.n_heads},
-        };
-
-        // Create a typed container, duplicate accessor attributes (strides, sizes, and offsets);
-        // and use the same container. After permutations, override the original container with
-        // the resulting container.
-        auto permute_attention = [&](nn::named_parameter param) {
-            for (auto& [re, n_heads] : permutations) {
-                if (std::regex_match(param.path, re)) {
-                    nn::permute_attention_heads<T>(param.ptr, n_heads, _M_accelerator);
-                    break;
-                }
-            }
-        };
-
-        layer.apply(permute_attention);
     }
 
 private:

--- a/include/metalchat/nn/attention.h
+++ b/include/metalchat/nn/attention.h
@@ -136,6 +136,8 @@ public:
     void
     enable_norm(float eps, float mu)
     {
+        _M_options.norm_eps = eps;
+        _M_options.norm_mu = mu;
         _M_wq_norm = register_layer<RMSNorm>("q_norm", eps, mu);
         _M_wk_norm = register_layer<RMSNorm>("k_norm", eps, mu);
     }
@@ -201,8 +203,9 @@ public:
 };
 
 
-/// This method performs adaptation of HuggingFace-style attention weight matrices (K, Q) to
-/// Meta-style shape.
+/// This method performs adaptation of reference Meta-style K and Q weight matrices to the
+/// HuggingFace-style attention weight matrices. This adaptation is necessary since MetalChat
+/// uses HuggingFace's approach to compute rotary position embeddings.
 ///
 /// \tparam Input type of the input tensor.
 /// \param input input attention tensor.
@@ -220,8 +223,8 @@ permute_attention_heads(const Input& input, std::size_t n_heads, hardware_accele
     //
     // This implementation performs transposition on-the-fly, inserts rows into the necessary
     // positions given the strides of the input and output tensors.
-    tensor_accessor input_layout({n_heads, 2, attention_heads});
-    tensor_accessor output_layout({n_heads, attention_heads, 2});
+    tensor_accessor input_layout({n_heads, attention_heads, 2});
+    tensor_accessor output_layout({n_heads, 2, attention_heads});
 
     std::vector<Input> tensors(size);
     for (std::size_t input_index = 0; input_index < size; input_index++) {

--- a/include/metalchat/nn/gemma.h
+++ b/include/metalchat/nn/gemma.h
@@ -103,7 +103,7 @@ public:
     operator()(Input input, std::size_t start_pos = 0)
     {
         auto x = _M_embedding(input);
-        x = mul(x, T(std::sqrt(_M_options.hidden_dim)), accelerator());
+        x = mul(x, T(std::sqrt(float(_M_options.hidden_dim))), accelerator());
 
         auto len = x.size(1);
         auto end_pos = std::min(start_pos + len, _M_options.max_seq_len);

--- a/include/metalchat/reference.h
+++ b/include/metalchat/reference.h
@@ -19,7 +19,7 @@ namespace metalchat {
 namespace reference {
 
 
-template <nn::mutable_layer Layer> class llama3_safetensor_serializer {
+template <typename T, nn::mutable_layer Layer> class llama3_safetensor_serializer {
 public:
     using value_type = nn::indirect_layer<Layer>;
 
@@ -37,6 +37,7 @@ public:
         value_type layer(_M_options, _M_accelerator);
         auto doc = adapt(document);
         doc.load(layer);
+        adapt(layer);
         return layer;
     }
 
@@ -55,6 +56,41 @@ public:
         auto doc = document;
         doc.insert("output.weight", "tok_embeddings.weight");
         return doc;
+    }
+
+    /// Perform permutation of the attention heads within Wq and Wk layers so that the order
+    /// of elements as in the HuggingFace's implementation.
+    ///
+    /// The Meta's reference implementation of attention layer differs from HuggingFace's
+    /// implementation. Specifically, the attention heads are permuted. This layer adaptor
+    /// performs a permutation to the shape expected in the HuggingFace's implementation.
+    ///
+    /// The side-effect of this adaptor is increase of a memory required to launch the model,
+    /// since after permutations weight tensors become discontiguous and their usage requires
+    /// copying them.
+    ///
+    /// \param layer a layer to adapt to the HuggingFace's implementation.
+    void
+    adapt(value_type& layer)
+    {
+        const std::vector<std::pair<std::regex, std::size_t>> permutations = {
+            {std::regex(R"(layers\.(\d+)\.attention\.wk\.weight)"), _M_options.n_kv_heads},
+            {std::regex(R"(layers\.(\d+)\.attention\.wq\.weight)"), _M_options.n_heads},
+        };
+
+        // Create a typed container, duplicate accessor attributes (strides, sizes, and offsets);
+        // and use the same container. After permutations, override the original container with
+        // the resulting container.
+        auto permute_attention = [&](nn::named_parameter param) {
+            for (auto& [re, n_heads] : permutations) {
+                if (std::regex_match(param.path, re)) {
+                    nn::permute_attention_heads<T>(param.ptr, n_heads, _M_accelerator);
+                    break;
+                }
+            }
+        };
+
+        layer.apply(permute_attention);
     }
 
 private:
@@ -137,7 +173,7 @@ template <contiguous_container Container> struct llama3_traits {
     using options_type = nn::llama3_options;
     using options_serializer = llama3_options_serializer;
     using layer_type = nn::llama3<value_type, container_type>;
-    using layer_serializer = llama3_safetensor_serializer<layer_type>;
+    using layer_serializer = llama3_safetensor_serializer<value_type, layer_type>;
     using tokenizer_type = text::byte_pair_encoder<text::regexp>;
     using tokenizer_loader = llama3_tokenizer_loader;
 };

--- a/kernel/bmm.metal
+++ b/kernel/bmm.metal
@@ -37,8 +37,8 @@ bmm(__bmm_parameters<T> params,
     const uint K = m1.size(2);
     const uint N = m2.size(2);
 
-    threadgroup T m1_local[BlockSize][BlockSize];
-    threadgroup T m2_local[BlockSize][BlockSize];
+    threadgroup float m1_local[BlockSize][BlockSize];
+    threadgroup float m2_local[BlockSize][BlockSize];
 
     const uint block_row = group_id.x * BlockSize;
     const uint block_col = group_id.y * BlockSize;
@@ -47,43 +47,33 @@ bmm(__bmm_parameters<T> params,
     const uint thread_row = thread_id.x;
     const uint thread_col = thread_id.y;
 
-    T partial = T(0.0);
+    float partial = 0.0f;
 
-    uint r1 = metal::min(block_row + thread_row, M - 1);
-    uint c2 = metal::min(block_col + thread_col, N - 1);
+    uint r1 = block_row + thread_row;
+    uint c2 = block_col + thread_col;
 
     for (uint k = 0; k < K; k += BlockSize) {
         uint c1 = k + thread_col;
-        if (c1 < K) {
-            m1_local[thread_row][thread_col] = m1.at(batch, r1, c1);
-        } else {
-            m1_local[thread_row][thread_col] = T(0.0);
-        }
+        m1_local[thread_row][thread_col] = (r1 < M && c1 < K) ? m1.at(batch, r1, c1) : 0.0f;
 
         uint r2 = k + thread_row;
-        if (r2 < K) {
-            m2_local[thread_row][thread_col] = m2.at(batch, r2, c2);
-        } else {
-            m2_local[thread_row][thread_col] = T(0.0);
-        }
+        m2_local[thread_row][thread_col] = (r2 < K && c2 < N) ? m2.at(batch, r2, c2) : 0.0f;
 
         threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
-        partial += m1_local[thread_row][0] * m2_local[0][thread_col];
-        partial += m1_local[thread_row][1] * m2_local[1][thread_col];
-        partial += m1_local[thread_row][2] * m2_local[2][thread_col];
-        partial += m1_local[thread_row][3] * m2_local[3][thread_col];
-        partial += m1_local[thread_row][4] * m2_local[4][thread_col];
-        partial += m1_local[thread_row][5] * m2_local[5][thread_col];
-        partial += m1_local[thread_row][6] * m2_local[6][thread_col];
-        partial += m1_local[thread_row][7] * m2_local[7][thread_col];
+#pragma unroll(BlockSize)
+        for (uint j = 0; j < BlockSize; ++j) {
+            partial += m1_local[thread_row][j] * m2_local[j][thread_col];
+        }
+
+        threadgroup_barrier(metal::mem_flags::mem_threadgroup);
     }
 
     uint row = block_row + thread_row;
     uint col = block_col + thread_col;
 
     if (row < M && col < N) {
-        out.at(batch, row, col) = partial;
+        out.at(batch, row, col) = T(partial);
     }
 }
 

--- a/kernel/rmsnorm.metal
+++ b/kernel/rmsnorm.metal
@@ -36,7 +36,7 @@ rmsnorm(
     uint simd_gid [[simdgroup_index_in_threadgroup]]
 )
 {
-    constexpr int SIMD_SIZE = 32;
+    constexpr uint SIMD_SIZE = 32;
 
     tensor2<const T> in(params.input_layout, params.input);
     tensor<const T, 1> w{params.weight, params.weight_layout};
@@ -51,7 +51,7 @@ rmsnorm(
     const uint end = begin + params.block_size;
 
     for (uint j = begin; j < end && j < dim_size; j++) {
-        float xj = float(in.at(i, j));
+        float xj = in.at(i, j);
         threadlocal_sum += xj * xj;
     }
 
@@ -61,8 +61,8 @@ rmsnorm(
     threadgroup float threadgroup_sum[SIMD_SIZE];
 
     //  Initialize shared memory
-    if (simd_gid == 0) {
-        threadgroup_sum[simd_tid] = 0;
+    if (simd_tid < SIMD_SIZE) {
+        threadgroup_sum[simd_tid] = 0.0f;
     }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
@@ -76,15 +76,17 @@ rmsnorm(
     if (simd_gid == 0) {
         acc = metal::simd_sum(threadgroup_sum[simd_tid]);
         if (simd_tid == 0) {
-            const float var = (acc / dim_size);
-            threadgroup_inv_mean[0] = metal::rsqrt(var + params.eps);
+            const float mean_sq = (acc / dim_size);
+            threadgroup_inv_mean[0] = metal::precise::rsqrt(mean_sq + params.eps);
         }
     }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
     // Write the outputs
     for (uint j = begin; j < end && j < dim_size; j++) {
-        out.at(i, j) = T((w.at(j) + params.mu) * in.at(i, j) * threadgroup_inv_mean[0]);
+        const float x = in.at(i, j);
+        const float weight = params.mu + w.at(j);
+        out.at(i, j) = T(weight * x * threadgroup_inv_mean[0]);
     }
 }
 

--- a/kernel/rope.metal
+++ b/kernel/rope.metal
@@ -38,23 +38,23 @@ rope(
     tensor2<const float> f_cos(params.freqs_cos_layout, params.freqs_cos);
     tensor2<const float> f_sin(params.freqs_sin_layout, params.freqs_sin);
 
-    const uint row_size = params.output.size(0);
+    const uint row_size = params.input.size(0);
     const uint head_dim = f_cos.size(1);
     const uint i = gid.y * threadgroup_size.y + tid.y;
     const uint k = gid.x * threadgroup_size.x + tid.x;
 
-    // numel = bs * seq_len * n_head * head_dim
+    // inputs size: (bs * seq_len * n_head, head_dim)
     const uint pos = i / (params.batch_size * params.n_head);
 
     if (i < row_size && k < head_dim) {
-        float x1 = params.input.at(i, 2 * k);
-        float x2 = params.input.at(i, 2 * k + 1);
+        float x1 = params.input.at(i, k);
+        float x2 = params.input.at(i, head_dim + k);
 
         float fcos = f_cos.at(params.start_pos + pos, k);
         float fsin = f_sin.at(params.start_pos + pos, k);
 
-        params.output.at(i, 2 * k) = T(fcos * x1 - fsin * x2);
-        params.output.at(i, 2 * k + 1) = T(fsin * x1 + fcos * x2);
+        params.output.at(i, k) = T(fcos * x1 - fsin * x2);
+        params.output.at(i, head_dim + k) = T(fsin * x1 + fcos * x2);
     }
 }
 
@@ -89,12 +89,12 @@ rope_freqs(
     const uint i = gid.y * threadgroup_size.y + tid.y;
     const uint j = gid.x * threadgroup_size.x + tid.x;
 
-    if (j < params.dim / 2) {
-        T freq = T(1.0) / metal::pow(params.theta, 2.0 * j / params.dim);
-        T angle = T(params.start_pos + i) * freq;
+    if (i < f_cos.size(0) && j < params.dim / 2) {
+        float freq = 1.0f / metal::precise::pow(params.theta, 2.0f * j / params.dim);
+        float angle = float(params.start_pos + i) * freq;
 
-        f_cos.at(i, j) = metal::cos(angle);
-        f_sin.at(i, j) = metal::sin(angle);
+        f_cos.at(i, j) = T(metal::precise::cos(angle));
+        f_sin.at(i, j) = T(metal::precise::sin(angle));
     }
 }
 

--- a/kernel/softmax.metal
+++ b/kernel/softmax.metal
@@ -43,7 +43,7 @@ softmax(
 
     for (uint j = begin; j < end && j < dim_size; j++) {
         float xj = float(params.input.at(i, j));
-        threadlocal_sum += metal::fast::exp(xj);
+        threadlocal_sum += metal::precise::exp(xj);
     }
 
     float acc = metal::simd_sum(threadlocal_sum);
@@ -52,7 +52,7 @@ softmax(
     threadgroup float threadgroup_sum[SIMD_SIZE];
 
     //  Initialize shared memory
-    if (simd_gid == 0) {
+    if (simd_tid < SIMD_SIZE) {
         threadgroup_sum[simd_tid] = 0;
     }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
@@ -67,15 +67,16 @@ softmax(
     if (simd_gid == 0) {
         acc = metal::simd_sum(threadgroup_sum[simd_tid]);
         if (simd_tid == 0) {
-            threadgroup_exp_sum[0] = 1 / acc;
+            threadgroup_exp_sum[0] = 1.0f / acc;
         }
     }
     threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
     // Write the outputs
-    T exp_sum = T(threadgroup_exp_sum[0]);
+    const float exp_sum = threadgroup_exp_sum[0];
     for (uint j = begin; j < end && j < dim_size; j++) {
-        params.output.at(i, j) = T(exp(params.input.at(i, j))) * exp_sum;
+        const float x = params.input.at(i, j);
+        params.output.at(i, j) = T(metal::precise::exp(x) * exp_sum);
     }
 }
 

--- a/test/test_gemma.cc
+++ b/test/test_gemma.cc
@@ -29,7 +29,7 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
 
     std::cout << id.get()[0, 0];
 
-    for (std::size_t i = input0.size(1); i < 30; i++) {
+    for (std::size_t i = input0.size(1); i < 64; i++) {
         id = transformer.transform(id, i);
         std::cout << ", " << id.get()[0, 0] << std::flush;
     }

--- a/test/test_llama.cc
+++ b/test/test_llama.cc
@@ -6,7 +6,7 @@
 
 #include <metalchat/accelerator.h>
 #include <metalchat/functional.h>
-#include <metalchat/reference.h>
+#include <metalchat/huggingface/llama.h>
 #include <metalchat/repository.h>
 #include <metalchat/tensor.h>
 #include <metalchat/text.h>
@@ -16,18 +16,18 @@
 using namespace metalchat;
 
 
-TEST_CASE("Test reference implementation inference", "[llama][integration]")
+TEST_CASE("Test Llama3 implementation", "[llama][integration]")
 {
-    auto repo_path = test_fixture_path() / "meta-llama/Llama-3.2-1B-Instruct/original";
+    auto repo_path = test_fixture_path() / "meta-llama/Llama-3.2-1B-Instruct";
 
-    auto gpu0 = metalchat::hardware_accelerator(64);
-    auto repository = filesystem_repository<reference::llama3>(repo_path, gpu0);
+    metalchat::hardware_accelerator gpu0;
+    filesystem_repository<huggingface::llama3> repository(repo_path, gpu0);
 
     auto options = nn::default_llama3_1b_options();
     options.max_seq_len = 16;
 
     auto transformer = repository.retrieve_transformer("model.safetensors", options);
-    auto tokenizer = repository.retrieve_tokenizer("tokenizer.model");
+    auto tokenizer = repository.retrieve_tokenizer("tokenizer.json");
 
     auto heap_size = std::size_t(512) * 1024 * 1024;
     auto alloc0 = hardware_heap_allocator<void>(gpu0.get_metal_device(), heap_size);

--- a/test/test_safetensor.cc
+++ b/test/test_safetensor.cc
@@ -62,7 +62,7 @@ public:
 TEST_CASE("Test model load", "[safetensor][integration]")
 {
     using layer_type = nn::llama3<bf16>;
-    using serializer_type = reference::llama3_safetensor_serializer<layer_type>;
+    using serializer_type = reference::llama3_safetensor_serializer<bf16, layer_type>;
     auto options = nn::default_llama3_1b_options();
 
     hardware_accelerator gpu0(16);


### PR DESCRIPTION
This patch changes implementation of the RoPE, so that it is the same as implementation in HuggingFace. Now instead of permuting attention heads during the load of weights using HuggingFace serializer, the library permutes attention heads only for a reference Llama implementation.