### PR TITLE
Introduce an option to share RoPE weights

### DIFF
--- a/include/metalchat/nn/attention.h
+++ b/include/metalchat/nn/attention.h
@@ -105,11 +105,13 @@ public:
     using value_type = T;
     using container_type = Container;
 
-    attention(const attention_options& options, hardware_accelerator accelerator)
-    : basic_layer(accelerator),
-      _M_rope(options.head_dim, options.max_seq_len, /*thetha=*/options.rope_theta, accelerator),
+    attention(
+        const attention_options& options, const indirect_layer<RotaryPositionalEmbedding>& rope
+    )
+    : basic_layer(rope.accelerator()),
+      _M_rope(rope),
       _M_options(options),
-      _M_clone(accelerator),
+      _M_clone(accelerator()),
       _M_scale(options.scale)
     {
         _M_wq = register_polymorphic_layer<Linear>("wq");
@@ -131,6 +133,15 @@ public:
             enable_norm(options.norm_eps.value(), options.norm_mu.value_or(0.0f));
         }
     }
+
+    attention(const attention_options& options, hardware_accelerator& accelerator)
+    : attention(
+          options,
+          indirect_layer<RotaryPositionalEmbedding>(
+              options.head_dim, options.max_seq_len, options.rope_theta, accelerator
+          )
+      )
+    {}
 
     /// Enable RMS-normalization of keys and queries.
     void

--- a/include/metalchat/nn/embedding.h
+++ b/include/metalchat/nn/embedding.h
@@ -126,7 +126,8 @@ private:
     auto
     alloc()
     {
-        return future_tensor(empty<float>({_M_seq_len, _M_dim / 2}, accelerator().get_allocator()));
+        auto allocator = accelerator().get_allocator();
+        return future_tensor(empty<float>({_M_seq_len, _M_dim / 2}, allocator));
     }
 
     void

--- a/include/metalchat/nn/gemma.h
+++ b/include/metalchat/nn/gemma.h
@@ -42,9 +42,11 @@ struct gemma3_options {
 template <typename T, contiguous_container Container = hardware_memory_container<T>>
 class gemma3 : public basic_layer {
 private:
+    using Attention = nn::attention<T, Container>;
     using Transformer = nn::transformer<T, Container, kernel::gelu<T>>;
     using TransformerArray = nn::layer_array<Transformer>;
     using Embedding = nn::embedding<T, Container>;
+    using RotaryPositionalEmbedding = nn::rope<T>;
     using RMSNorm = nn::rmsnorm<T, Container>;
     using Linear = nn::linear<T, Container>;
 
@@ -77,8 +79,15 @@ public:
         _M_embedding = register_layer<Embedding>("tok_embeddings");
         _M_output = register_layer<Linear>("output");
 
+        indirect_layer<RotaryPositionalEmbedding> sliding_rope(
+            options.head_dim, options.max_seq_len, options.rope_sliding_theta, accelerator
+        );
+        indirect_layer<RotaryPositionalEmbedding> rolling_rope(
+            options.head_dim, options.max_seq_len, options.rope_theta, accelerator
+        );
+
         for (std::size_t i = 0; i < options.n_layers; i++) {
-            auto rope_theta = is_sliding(i) ? options.rope_sliding_theta : options.rope_theta;
+            auto rope = is_sliding(i) ? sliding_rope : rolling_rope;
 
             attention_options attention_opts{
                 .head_dim = options.head_dim,
@@ -86,13 +95,13 @@ public:
                 .n_kv_heads = options.n_kv_heads,
                 .max_seq_len = options.max_seq_len,
                 .max_batch_size = 1,
-                .rope_theta = rope_theta,
+                .rope_theta = options.rope_theta,
                 .scale = 1.0f / std::sqrt(options.attn_scale),
                 .norm_eps = options.norm_eps,
                 .norm_mu = 1.0f
             };
 
-            _M_transforms->emplace_back(attention_opts, accelerator);
+            _M_transforms->emplace_back(indirect_layer<Attention>(attention_opts, rope));
             _M_transforms->back().enable_norm(options.norm_eps, /*mu=*/1.0f);
             _M_transforms->back().enable_post_norm(options.norm_eps, /*mu=*/1.0f);
         }

--- a/include/metalchat/nn/llama.h
+++ b/include/metalchat/nn/llama.h
@@ -43,10 +43,12 @@ default_llama3_1b_options();
 template <typename T, contiguous_container Container = hardware_memory_container<T>>
 class llama3 : public basic_layer {
 private:
+    using Attention = nn::attention<T, Container>;
     using Transformer = nn::transformer<T, Container>;
     using TransformerArray = nn::layer_array<Transformer>;
     using BasicEmbedding = nn::basic_embedding<T, Container>;
     using Embedding = nn::embedding<T, Container>;
+    using RotaryPositionalEmbedding = nn::rope<T>;
     using RMSNorm = nn::rmsnorm<T, Container>;
     using BasicLinear = nn::basic_linear<T, Container>;
     using Linear = nn::linear<T, Container>;
@@ -90,8 +92,13 @@ public:
             .norm_mu = std::nullopt,
         };
 
+        indirect_layer<RotaryPositionalEmbedding> rope(
+            options.head_dim, options.max_seq_len, options.rope_theta, accelerator
+        );
+
         for (std::size_t i = 0; i < options.n_layers; i++) {
-            _M_transforms->emplace_back(attention_opts, accelerator);
+            indirect_layer<Attention> attention(attention_opts, rope);
+            _M_transforms->emplace_back(attention);
             _M_transforms->back().enable_norm(options.norm_eps);
         }
     }

--- a/include/metalchat/nn/transformer.h
+++ b/include/metalchat/nn/transformer.h
@@ -90,12 +90,16 @@ public:
     using value_type = T;
     using container_type = Container;
 
-    transformer(const attention_options& options, hardware_accelerator& accelerator)
-    : basic_layer(accelerator)
+    transformer(const indirect_layer<Attention>& attention)
+    : basic_layer(attention.accelerator())
     {
-        _M_attention = register_layer<Attention>("attention", options);
+        _M_attention = register_layer("attention", attention);
         _M_ff = register_layer<FeedForward>("feed_forward");
     }
+
+    transformer(const attention_options& options, hardware_accelerator& accelerator)
+    : transformer(indirect_layer<Attention>(options, accelerator))
+    {}
 
     /// Enable normalization of the attention and feed-forward layers.
     ///


### PR DESCRIPTION
This patch changes construction of Llama and Gemma, so that RoPE weight tensors are shared between multiple attention layers, avoiding so unnecessary recomputations.