### PR TITLE
Rename function name to `uses_sliding_attention`

### DIFF
--- a/include/metalchat/nn/gemma.h
+++ b/include/metalchat/nn/gemma.h
@@ -59,7 +59,7 @@ private:
     gemma3_options _M_options;
 
     inline bool
-    is_sliding(std::size_t i) const
+    uses_sliding_attention(std::size_t i) const
     {
         return (i + 1) % _M_options.sliding_stride;
     }
@@ -87,7 +87,7 @@ public:
         );
 
         for (std::size_t i = 0; i < options.n_layers; i++) {
-            auto rope = is_sliding(i) ? sliding_rope : rolling_rope;
+            auto rope = uses_sliding_attention(i) ? sliding_rope : rolling_rope;
 
             attention_options attention_opts{
                 .head_dim = options.head_dim,
@@ -124,7 +124,7 @@ public:
 
         for (std::size_t i = 0; i < _M_transforms->size(); i++) {
             auto& transform = _M_transforms->at(i);
-            auto& mask = is_sliding(i) ? sliding_mask : rolling_mask;
+            auto& mask = uses_sliding_attention(i) ? sliding_mask : rolling_mask;
             x = transform(x, mask, start_pos);
         }
 

--- a/test/test_gemma.cc
+++ b/test/test_gemma.cc
@@ -17,11 +17,16 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
 {
     auto repo_path = test_fixture_path() / "google/gemma-3-270m-it";
 
-    hardware_accelerator gpu0;
+    hardware_accelerator gpu0(64);
     filesystem_repository<huggingface::gemma3> repository(repo_path, gpu0);
 
     auto options = repository.retrieve_options("config.json");
     auto transformer = repository.retrieve_transformer("model.safetensors", options);
+
+    auto heap_size = std::size_t(512) * 1024 * 1024;
+    auto alloc0 = hardware_heap_allocator<void>(gpu0.get_metal_device(), heap_size);
+    auto alloc1 = nocopy_allocator(alloc0, gpu0.get_metal_device());
+    gpu0.set_allocator(std::move(alloc1));
 
     std::vector<int32_t> ids({2, 236777, 735, 496, 4799, 2760});
     auto input0 = shared_tensor(to_tensor<int32_t>({1, ids.size()}, ids.begin(), ids.end()));
@@ -29,7 +34,7 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
 
     std::cout << id.get()[0, 0];
 
-    for (std::size_t i = input0.size(1); i < 64; i++) {
+    for (std::size_t i = input0.size(1); i < 32; i++) {
         id = transformer.transform(id, i);
         std::cout << ", " << id.get()[0, 0] << std::flush;
     }


### PR DESCRIPTION
This patch renames a method to identify layer attention type.