### PR TITLE
Unicode BPE-tokenizer

### DIFF
--- a/include/metalchat/accelerator.h
+++ b/include/metalchat/accelerator.h
@@ -29,7 +29,16 @@ static const std::string framework_identifier = __lib_metalchat_framework_identi
 
 struct _StringHash {
     std::size_t
-    operator()(const std::string& s) const noexcept;
+    operator()(const void* s, std::size_t len) const noexcept;
+
+    template <typename CharT>
+    std::size_t
+    operator()(const std::basic_string<CharT>& s) const noexcept
+    {
+        using String = std::basic_string<CharT>;
+
+        return operator()(s.data(), sizeof(typename String::value_type) * s.size());
+    }
 };
 
 

--- a/include/metalchat/huggingface/gemma.h
+++ b/include/metalchat/huggingface/gemma.h
@@ -88,6 +88,17 @@ private:
 };
 
 
+struct gemma3_tokenizer_loader {
+    using type = text::byte_pair_encoder<char32_t>;
+
+    type
+    load(std::istream& is) const;
+
+    type
+    load(const std::filesystem::path& p) const;
+};
+
+
 template <contiguous_container Container> struct gemma3_traits {
     using value_type = Container::value_type;
     using container_type = Container;
@@ -98,8 +109,8 @@ template <contiguous_container Container> struct gemma3_traits {
     using options_type = nn::gemma3_options;
     using options_serializer = gemma3_options_serializer;
 
-    using tokenizer_type = text::byte_pair_encoder<text::regexp>;
-    using tokenizer_loader = void;
+    using tokenizer_type = text::byte_pair_encoder<char32_t>;
+    using tokenizer_loader = gemma3_tokenizer_loader;
 };
 
 

--- a/include/metalchat/huggingface/llama.h
+++ b/include/metalchat/huggingface/llama.h
@@ -186,7 +186,7 @@ private:
 /// queries necessary tokens of data from the `tokenizer.json` file in order to replicate the
 /// original tiktoken format.
 struct llama3_tokenizer_loader {
-    using type = text::byte_pair_encoder<text::regexp>;
+    using type = text::byte_pair_encoder<char>;
 
     /// Load the tokenizer from the specified input stream.
     ///
@@ -212,7 +212,7 @@ template <contiguous_container Container> struct llama3_traits {
     using options_type = nn::llama3_options;
     using options_serializer = llama3_options_serializer;
 
-    using tokenizer_type = text::byte_pair_encoder<text::regexp>;
+    using tokenizer_type = text::byte_pair_encoder<char>;
     using tokenizer_loader = llama3_tokenizer_loader;
 
     static constexpr std::string_view tokenizer_location = "tokenizer.json";
@@ -232,7 +232,7 @@ template <contiguous_container Container> struct llama3_qlora_traits {
     using options_type = nn::llama3_options;
     using options_serializer = llama3_options_serializer;
 
-    using tokenizer_type = text::byte_pair_encoder<text::regexp>;
+    using tokenizer_type = text::byte_pair_encoder<char>;
     using tokenizer_loader = reference::llama3_tokenizer_loader;
 };
 

--- a/include/metalchat/reference.h
+++ b/include/metalchat/reference.h
@@ -117,7 +117,7 @@ struct llama3_options_serializer {
 /// This loader implements loading of a tokenizer model in a reference (tiktoken) format. It
 /// expects that `load` methods receives a file in a tiktoken format.
 struct llama3_tokenizer_loader {
-    using type = text::byte_pair_encoder<text::regexp>;
+    using type = text::byte_pair_encoder<char>;
 
     /// A regular expression string that is used to split the input text into tokens.
     // clang-format off
@@ -174,7 +174,7 @@ template <contiguous_container Container> struct llama3_traits {
     using options_serializer = llama3_options_serializer;
     using layer_type = nn::llama3<value_type, container_type>;
     using layer_serializer = llama3_safetensor_serializer<value_type, layer_type>;
-    using tokenizer_type = text::byte_pair_encoder<text::regexp>;
+    using tokenizer_type = text::byte_pair_encoder<char>;
     using tokenizer_loader = llama3_tokenizer_loader;
 };
 

--- a/include/metalchat/text/bpe.h
+++ b/include/metalchat/text/bpe.h
@@ -59,10 +59,10 @@ make_reserved_token(int32_t index);
 
 /// A concept that requires an iterator to dereference a tuple comprised of three elements:
 /// (i) token string representation, (ii) token index, and (iii) type of the token.
-template <typename It, typename T = std::iterator_traits<It>::value_type>
+template <typename It, typename CharT, typename T = std::iterator_traits<It>::value_type>
 concept input_token_iterator_t = requires {
     requires std::input_iterator<It>;
-    requires std::same_as<T, std::tuple<std::string, int32_t, tokenkind>>;
+    requires std::same_as<T, std::tuple<std::basic_string<CharT>, int32_t, tokenkind>>;
 };
 
 
@@ -88,16 +88,17 @@ concept input_token_iterator_t = requires {
 /// ```cpp
 /// using namespace metalchat::text;
 ///
-/// byte_pair_encoder<text::regexp> tokenizer("tokenizer.model");
+/// byte_pair_encoder<char> tokenizer("tokenizer.model");
 /// auto tokens = tokenizer.encode("This is a test sentence.");
 /// auto string = tokenizer.decode(tokens.begin(), tokens.end());
 ///
 /// std::cout << string << std::endl;
 /// // output: This is a test sentence.
 /// ```
-template <typename RegularExpression> class byte_pair_encoder {
+template <typename CharT, typename RegularExpression = unicode_regexp<CharT>>
+class byte_pair_encoder {
 public:
-    using string_type = std::string;
+    using string_type = std::basic_string<CharT>;
 
     /// Type used to indicate position of the token in the model (token dictionary).
     using index_type = int32_t;
@@ -130,7 +131,7 @@ private:
     /// 4. Then push encodings to the specified container of identifiers.
     template <std::output_iterator<index_type> OutputIt>
     void
-    _M_encode_byte_pairs(const std::string& s, OutputIt output) const
+    _M_encode_unicode_pairs(const string_type& s, OutputIt output) const
     {
         std::size_t priority_limit = std::numeric_limits<index_type>::max();
 
@@ -142,7 +143,7 @@ private:
 
         // Get the priority from the map, when the key is not presented, return a
         // limit of the priority type.
-        auto get_priority = [&](const std::string& key) -> index_type {
+        auto get_priority = [&](const string_type& key) -> index_type {
             if (auto it = _M_forward_mapping.find(key); it != _M_forward_mapping.end()) {
                 return it->second;
             }
@@ -195,7 +196,8 @@ public:
     /// The \ref byte_pair_encoder copy constructor.
     byte_pair_encoder(const byte_pair_encoder&) = default;
 
-    byte_pair_encoder(const std::string& token_regex)
+    byte_pair_encoder(const string_type& token_regex)
+        requires std::constructible_from<RegularExpression, string_type>
     : _M_forward_mapping(),
       _M_inverse_mapping(),
       _M_control_mapping(),
@@ -209,12 +211,12 @@ public:
     ///
     /// \param is An input stream containing tokenizer model.
     /// \param token_regex A regular expression to split the input string into tokens.
-    byte_pair_encoder(std::istream& is, const std::string& token_regex)
+    byte_pair_encoder(std::istream& is, const string_type& token_regex)
     : byte_pair_encoder(token_regex)
     {
-        std::string line;
+        string_type line;
         while (std::getline(is, line)) {
-            auto delim = line.find(" ");
+            auto delim = line.find(' ');
             auto key_part = line.substr(0, delim);
             auto value_part = line.substr(delim + 1);
 
@@ -225,8 +227,8 @@ public:
         }
     }
 
-    template <input_token_iterator_t InputIt>
-    byte_pair_encoder(InputIt first, InputIt last, const std::string& token_regex)
+    template <input_token_iterator_t<CharT> InputIt>
+    byte_pair_encoder(InputIt first, InputIt last, const string_type& token_regex)
     : byte_pair_encoder(token_regex)
     {
         for (auto it = first; it != last; ++it) {
@@ -235,7 +237,7 @@ public:
         }
     }
 
-    byte_pair_encoder(std::istream&& is, const std::string& token_regex)
+    byte_pair_encoder(std::istream&& is, const string_type& token_regex)
     : byte_pair_encoder(is, token_regex)
     {}
 
@@ -246,7 +248,7 @@ public:
     ///
     /// \param p A path to the tokenizer model.
     /// \param token_regex A regular expression to split the input string into tokens.
-    byte_pair_encoder(const std::filesystem::path& p, const std::string& token_regex)
+    byte_pair_encoder(const std::filesystem::path& p, const string_type& token_regex)
     : byte_pair_encoder(std::ifstream(p, std::ios::binary), token_regex)
     {}
 
@@ -254,7 +256,7 @@ public:
     ///
     /// \param path A path to the tokenizer model.
     /// \param token_regex A regular expression to split the input string into tokens.
-    byte_pair_encoder(const char* path, const std::string& token_regex)
+    byte_pair_encoder(const char* path, const string_type& token_regex)
     : byte_pair_encoder(std::filesystem::path(path), token_regex)
     {}
 
@@ -264,7 +266,7 @@ public:
     /// \param key Target encoding of a token (a position in the token embedding).
     /// \param kind A type of the token, used for special token binding.
     void
-    insert(const std::string& value, index_type key, tokenkind kind = token::regular)
+    insert(const string_type& value, index_type key, tokenkind kind = token::regular)
     {
         _M_forward_mapping.insert_or_assign(value, key);
         _M_inverse_mapping.insert_or_assign(key, value);
@@ -279,7 +281,7 @@ public:
     /// \param value A string representation of a token.
     /// \param kind A type of the token, used for special token binding.
     void
-    insert_back(const std::string& value, tokenkind kind = token::regular)
+    insert_back(const string_type& value, tokenkind kind = token::regular)
     {
         auto key = static_cast<index_type>(size());
         insert(value, key, kind);
@@ -300,14 +302,14 @@ public:
     /// appended to the end of the container.
     template <std::output_iterator<index_type> OutputIt>
     void
-    encode(const std::string& s, OutputIt output) const
+    encode(const string_type& s, OutputIt output) const
     {
         for (auto match = _M_re->begin(s); match != _M_re->end(); ++match) {
             auto key = (*match);
             if (auto it = _M_forward_mapping.find(key); it != _M_forward_mapping.end()) {
                 *output++ = it->second;
             } else {
-                _M_encode_byte_pairs(key, output);
+                _M_encode_unicode_pairs(key, output);
             }
         }
     }
@@ -316,7 +318,7 @@ public:
     ///
     /// Method returns a position of a special token within a tokenizer model. When a token is
     /// a `token::regular` kind, then method raises an exception. Regular token encoding is
-    /// available through \ref encode(const std::string&, OutputIt) const method.
+    /// available through \ref encode(const string_type&, OutputIt) const method.
     index_type
     encode(tokenkind kind) const
     {
@@ -339,7 +341,7 @@ public:
     }
 
     auto
-    encode(const std::string& s) const
+    encode(const string_type& s) const
     {
         std::vector<index_type> output;
         encode(s, std::back_inserter(output));
@@ -350,7 +352,7 @@ public:
     ///
     /// Method at first attempts to find a token within a model token map, then tries to
     /// query special tokens. In token is not found, method raises an exception.
-    const std::string
+    const string_type
     decode(index_type id) const
     {
         if (auto tok = _M_inverse_mapping.find(id); tok != _M_inverse_mapping.end()) {
@@ -364,7 +366,7 @@ public:
     /// The result of decoding is sequentially appended to the specified container. If one
     /// of the tokens is not decoded correctly, an exception is raised. All successfully
     /// decoded tokens before thrown exception are left in the container.
-    template <std::forward_iterator ForwardIt, std::output_iterator<std::string> OutputIt>
+    template <std::forward_iterator ForwardIt, std::output_iterator<string_type> OutputIt>
     void
     decode(ForwardIt first, ForwardIt last, OutputIt output) const
     {
@@ -377,17 +379,17 @@ public:
     ///
     /// All decoded tokens will be concatenated into a resulting string.
     template <std::forward_iterator ForwardIt>
-    std::string
+    string_type
     decode(ForwardIt first, ForwardIt last) const
     {
-        std::stringstream output;
-        decode(first, last, std::ostream_iterator<std::string>(output));
+        std::basic_stringstream<CharT> output;
+        decode(first, last, std::ostream_iterator<string_type>(output));
         return output.str();
     }
 };
 
 
-using bpe = byte_pair_encoder<regexp>;
+using bpe = byte_pair_encoder<char>;
 
 
 } // namespace text

--- a/include/metalchat/text/regexp.h
+++ b/include/metalchat/text/regexp.h
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// SPDX-FileCopyrightText: 2025 Yakau Bubnou
+// SPDX-FileCopyrightText: 2026 Yakau Bubnou
 // SPDX-FileType: SOURCE
 
 #pragma once
 
+#include <codecvt>
 #include <format>
 #include <iterator>
+#include <locale>
 #include <memory>
 #include <string>
 
@@ -86,6 +88,101 @@ private:
     get();
 
     friend class regexp;
+};
+
+
+template <typename CharT> class unicode_regexp_iterator {
+private:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    using codecvt_type = std::codecvt_utf8<CharT>;
+    using convert_type = std::wstring_convert<codecvt_type, CharT>;
+#pragma clang diagnostic pop
+
+    convert_type _M_convert;
+    regexp_iterator _M_it;
+
+public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = std::basic_string<CharT>;
+    using reference = value_type&;
+    using pointer = value_type*;
+    using difference_type = std::ptrdiff_t;
+
+    unicode_regexp_iterator()
+    : _M_convert(),
+      _M_it()
+    {}
+
+    unicode_regexp_iterator(const regexp_iterator& it)
+    : _M_convert(),
+      _M_it(it)
+    {}
+
+    unicode_regexp_iterator&
+    operator++()
+    {
+        ++_M_it;
+        return *this;
+    }
+
+    value_type
+    operator*()
+    {
+        auto us = *_M_it;
+        return _M_convert.from_bytes(us);
+    }
+
+    bool
+    operator!=(const unicode_regexp_iterator& other)
+    {
+        return _M_it != other._M_it;
+    }
+};
+
+
+template <typename CharT> class unicode_regexp {
+private:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    using codecvt_type = std::codecvt_utf8<CharT>;
+    using convert_type = std::wstring_convert<codecvt_type, CharT>;
+#pragma clang diagnostic pop
+
+    convert_type _M_convert;
+    regexp _M_re;
+
+public:
+    using iterator = unicode_regexp_iterator<CharT>;
+
+    unicode_regexp(const std::basic_string<CharT>& regex)
+    : _M_convert(),
+      _M_re(_M_convert.to_bytes(regex.data(), regex.data() + regex.size()))
+    {}
+
+    unicode_regexp(const std::string& regex)
+    : _M_convert(),
+      _M_re(regex)
+    {}
+
+    iterator
+    begin(const std::basic_string<CharT>& s)
+    {
+        auto bytes = _M_convert.to_bytes(s.data(), s.data() + s.size());
+        return iterator(_M_re.begin(bytes));
+    }
+
+    iterator
+    end()
+    {
+        return iterator();
+    }
+};
+
+
+template <> class unicode_regexp<char> : public regexp {
+public:
+    using regexp::regexp;
 };
 
 

--- a/src/accelerator.cc
+++ b/src/accelerator.cc
@@ -17,9 +17,9 @@ namespace metalchat {
 
 
 std::size_t
-_StringHash::operator()(const std::string& s) const noexcept
+_StringHash::operator()(const void* s, std::size_t len) const noexcept
 {
-    return rapidhash(s.c_str(), s.size());
+    return rapidhash(s, len);
 }
 
 

--- a/src/gemma.cc
+++ b/src/gemma.cc
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: 2026 Yakau Bubnou
 // SPDX-FileType: SOURCE
 
+#include <codecvt>
+#include <locale>
+
 #include <jsoncons/json.hpp>
 
 #include <metalchat/huggingface/gemma.h>
@@ -63,6 +66,44 @@ gemma3_options_serializer::save(std::ostream& os, const nn::gemma3_options& opti
                               .precision(os.precision());
 
     jsoncons::encode_json<options_type>(hf_options, os, encode_options);
+}
+
+
+gemma3_tokenizer_loader::type
+gemma3_tokenizer_loader::load(std::istream& is) const
+{
+    using model_type = metalchat::huggingface::detail::tokenizer;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    using codecvt_type = std::codecvt_utf8<char32_t>;
+    using convert_type = std::wstring_convert<codecvt_type, char32_t>;
+    convert_type convert;
+#pragma clang diagnostic pop
+
+    auto model_file = jsoncons::decode_json<model_type>(is);
+    gemma3_tokenizer_loader::type tokenizer(UR"(.*)");
+
+    for (const auto& [value, key] : model_file.model.vocab) {
+        tokenizer.insert(convert.from_bytes(value), key, text::token::regular);
+    }
+    for (const auto& token : model_file.added_tokens) {
+        tokenizer.insert(convert.from_bytes(token.content), token.id, text::tokenkind(token.id));
+    }
+
+    return tokenizer;
+}
+
+gemma3_tokenizer_loader::type
+gemma3_tokenizer_loader::load(const std::filesystem::path& p) const
+{
+    std::ifstream file(p, std::ios::binary | std::ios::in);
+    if (!file.is_open()) {
+        throw std::invalid_argument(
+            std::format("gemma3_tokenizer_loader: failed opening file '{}'", p.string())
+        );
+    }
+
+    return load(file);
 }
 
 

--- a/src/huggingface.h
+++ b/src/huggingface.h
@@ -48,7 +48,7 @@ struct gemma3_options {
 
 
 struct special_token {
-    std::string id;
+    std::size_t id;
     std::string content;
     bool single_word;
     bool lstrip;
@@ -106,7 +106,7 @@ struct bpe {
 struct tokenizer {
     std::string version;
     std::vector<special_token> added_tokens;
-    sequence_tokenizer pre_tokenizer;
+    std::variant<sequence_tokenizer, split_tokenizer> pre_tokenizer;
     bpe model;
 };
 
@@ -148,10 +148,10 @@ JSONCONS_N_MEMBER_TRAITS(
 );
 
 JSONCONS_ALL_MEMBER_TRAITS(hf::special_token, id, content, single_word, lstrip, rstrip, normalized, special);
-JSONCONS_ALL_MEMBER_TRAITS(hf::split_pattern, Regex);
+JSONCONS_N_MEMBER_TRAITS(hf::split_pattern, 0, Regex, String);
 JSONCONS_ALL_MEMBER_TRAITS(hf::split_tokenizer, type, behavior, pattern, invert);
 JSONCONS_ALL_MEMBER_TRAITS(hf::bytelevel_tokenizer, type, add_prefix_space, trim_offsets, use_regex);
 JSONCONS_ALL_MEMBER_TRAITS(hf::sequence_tokenizer, type, pretokenizers);
 JSONCONS_ALL_MEMBER_TRAITS(hf::bpe, fuse_unk, byte_fallback, ignore_merges, vocab, merges);
-JSONCONS_ALL_MEMBER_TRAITS(hf::tokenizer, version, added_tokens, pre_tokenizer, model);
+JSONCONS_N_MEMBER_TRAITS(hf::tokenizer, 0, version, added_tokens, pre_tokenizer, model);
 // clang-format on

--- a/src/llama.cc
+++ b/src/llama.cc
@@ -81,18 +81,24 @@ llama3_options_serializer::save(std::ostream& os, const nn::llama3_options& opti
 llama3_tokenizer_loader::type
 llama3_tokenizer_loader::load(std::istream& is) const
 {
-    using model_type = metalchat::huggingface::detail::tokenizer;
-    using split_tokenizer_type = metalchat::huggingface::detail::split_tokenizer;
-    using loader_type = metalchat::reference::llama3_tokenizer_loader;
-
-    auto model_file = jsoncons::decode_json<model_type>(is);
+    namespace hf = metalchat::huggingface::detail;
+    auto model_file = jsoncons::decode_json<hf::tokenizer>(is);
     std::string token_regex;
 
-    for (const auto& tokenizer : model_file.pre_tokenizer.pretokenizers) {
-        if (const auto split = std::get_if<split_tokenizer_type>(&tokenizer)) {
-            token_regex = split->pattern.Regex;
-            break;
+    if (const auto seq = std::get_if<hf::sequence_tokenizer>(&model_file.pre_tokenizer)) {
+        for (const auto tokenizer : seq->pretokenizers) {
+            if (const auto split = std::get_if<hf::split_tokenizer>(&tokenizer)) {
+                token_regex = split->pattern.Regex;
+                break;
+            }
         }
+    }
+
+    if (token_regex.empty()) {
+        throw std::runtime_error(
+            "llama3_tokenizer_loader::load: the JSON encoding does not provide "
+            "an input sequence regular expression"
+        );
     }
 
     text::gpt2_codec codec;
@@ -103,6 +109,7 @@ llama3_tokenizer_loader::load(std::istream& is) const
         tokenizer.insert(val, key, text::token::regular);
     }
 
+    using loader_type = metalchat::reference::llama3_tokenizer_loader;
     loader_type::insert_control_tokens(tokenizer);
     return tokenizer;
 }

--- a/src/regexp.cc
+++ b/src/regexp.cc
@@ -35,8 +35,8 @@ regexp::regexp(const std::string& regex)
     PCRE2_SIZE error_offset;
 
     auto re_ptr = pcre2_compile(
-        reinterpret_cast<PCRE2_SPTR>(regex.c_str()), PCRE2_ZERO_TERMINATED, 0, &error_code,
-        &error_offset, nullptr
+        reinterpret_cast<PCRE2_SPTR>(regex.data()), regex.size(), 0, &error_code, &error_offset,
+        nullptr
     );
 
     if (re_ptr == nullptr) {
@@ -74,35 +74,31 @@ struct regexp_iterator::_RegularExpressionIterator {
     friend class regexp;
 
     const std::shared_ptr<pcre2_code> _M_re = nullptr;
-    pcre2_match_data* _M_data = nullptr;
-    const PCRE2_SPTR _M_subject = nullptr;
-    const PCRE2_SIZE _M_subject_length = 0;
+    std::shared_ptr<pcre2_match_data> _M_data = nullptr;
+    std::string _M_subject;
     PCRE2_SIZE _M_offset = 0;
     bool _M_end = false;
 
     _RegularExpressionIterator()
     : _M_re(nullptr),
       _M_data(nullptr),
-      _M_subject(nullptr),
-      _M_subject_length(0),
+      _M_subject(),
       _M_offset(0),
       _M_end(true)
     {}
 
     _RegularExpressionIterator(const regexp& regex, const std::string& input)
     : _M_re(regex._M_impl->ptr),
-      _M_data(pcre2_match_data_create_from_pattern(regex._M_impl->ptr.get(), nullptr)),
-      _M_subject(reinterpret_cast<PCRE2_SPTR>(input.c_str())),
-      _M_subject_length(input.size()),
+      _M_data(nullptr),
+      _M_subject(input),
       _M_offset(0),
       _M_end(false)
-    {}
-
-    ~_RegularExpressionIterator()
     {
-        if (_M_data != nullptr) {
-            pcre2_match_data_free(_M_data);
-        }
+        pcre2_code* code = regex._M_impl->ptr.get();
+        pcre2_match_data* match_data = pcre2_match_data_create_from_pattern(code, nullptr);
+
+        _M_data = std::shared_ptr<pcre2_match_data>(match_data, pcre2_match_data_free);
+        _M_end = pcre2_get_ovector_count(match_data) == 0;
     }
 };
 
@@ -152,22 +148,28 @@ regexp_iterator::get()
         );
     }
 
-    PCRE2_SIZE* ovector = pcre2_get_ovector_pointer(_M_impl->_M_data);
-    PCRE2_SIZE length = ovector[1] - ovector[0];
+    pcre2_match_data* match_data = _M_impl->_M_data.get();
 
-    _M_impl->_M_offset = ovector[1];
+    PCRE2_SIZE* slice = pcre2_get_ovector_pointer(match_data);
+    PCRE2_SIZE length = slice[1] - slice[0];
 
-    value_type result(reinterpret_cast<const char*>(_M_impl->_M_subject + ovector[0]), length);
-    return result;
+    auto data = _M_impl->_M_subject.data() + _M_impl->_M_offset;
+    _M_impl->_M_offset = slice[1];
+    _M_impl->_M_end |= _M_impl->_M_subject.size() == _M_impl->_M_offset;
+
+    return value_type(reinterpret_cast<const char*>(data), length);
 }
 
 
 void
 regexp_iterator::next()
 {
+    pcre2_match_data* match_data = _M_impl->_M_data.get();
+    const PCRE2_SPTR subject = reinterpret_cast<PCRE2_SPTR>(_M_impl->_M_subject.data());
+    const PCRE2_SIZE subject_size = _M_impl->_M_subject.size();
+
     auto rc = pcre2_match(
-        _M_impl->_M_re.get(), _M_impl->_M_subject, _M_impl->_M_subject_length, _M_impl->_M_offset,
-        0, _M_impl->_M_data, NULL
+        _M_impl->_M_re.get(), subject, subject_size, _M_impl->_M_offset, 0, match_data, NULL
     );
     if (rc < 0) {
         _M_impl->_M_end = true;

--- a/test/test_gemma.cc
+++ b/test/test_gemma.cc
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// SPDX-FileCopyrightText: 2025 Yakau Bubnou
+// SPDX-FileCopyrightText: 2026 Yakau Bubnou
 // SPDX-FileType: SOURCE
+
+#include <codecvt>
+#include <locale>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -17,10 +20,16 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
 {
     auto repo_path = test_fixture_path() / "google/gemma-3-270m-it";
 
-    hardware_accelerator gpu0(64);
+    hardware_accelerator gpu0;
     filesystem_repository<huggingface::gemma3> repository(repo_path, gpu0);
 
     auto options = repository.retrieve_options("config.json");
+    auto tokenizer = repository.retrieve_tokenizer("tokenizer.json");
+
+    std::vector<int32_t> ids;
+    tokenizer.encode(text::token::begin_text, std::back_inserter(ids));
+    tokenizer.encode(UR"(I▁have▁a▁dog▁called)", std::back_inserter(ids));
+
     auto transformer = repository.retrieve_transformer("model.safetensors", options);
 
     auto heap_size = std::size_t(512) * 1024 * 1024;
@@ -28,14 +37,17 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
     auto alloc1 = nocopy_allocator(alloc0, gpu0.get_metal_device());
     gpu0.set_allocator(std::move(alloc1));
 
-    std::vector<int32_t> ids({2, 236777, 735, 496, 4799, 2760});
     auto input0 = shared_tensor(to_tensor<int32_t>({1, ids.size()}, ids.begin(), ids.end()));
     auto id = transformer.transform(input0);
 
-    std::cout << id.get()[0, 0];
+    using convert_type = std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t>;
+    convert_type convert;
+
+    std::cout << "I have a dog called";
+    std::cout << convert.to_bytes(tokenizer.decode(id.get()[0, 0]));
 
     for (std::size_t i = input0.size(1); i < 32; i++) {
         id = transformer.transform(id, i);
-        std::cout << ", " << id.get()[0, 0] << std::flush;
+        std::cout << convert.to_bytes(tokenizer.decode(id.get()[0, 0])) << std::flush;
     }
 }

--- a/test/test_kernel_bmm.cc
+++ b/test/test_kernel_bmm.cc
@@ -64,10 +64,10 @@ TEST_CASE("Matmul single batch multiplication", "[kernel::bmm]")
 TEST_CASE("Matmul large 2d", "[!benchmark][kernel::bmm]")
 {
     metalchat::hardware_accelerator gpu0;
-    kernel::bmm<float> mm(gpu0);
+    kernel::bmm<bf16> mm(gpu0);
 
-    auto input1 = shared_tensor(full<float>({8, 2048}, 2.0));
-    auto input2 = shared_tensor(full<float>({2048, 128256}, 1.0));
+    auto input1 = shared_tensor(full<bf16>({8, 2048}, 2.0));
+    auto input2 = shared_tensor(full<bf16>({2048, 128256}, 1.0));
 
     BENCHMARK("multiply 128256 elements")
     {


### PR DESCRIPTION
This patch modified the BPE tokenizer implementation, so now it is capable of joining unicode code points, and not only specific byte pairs. This is necessary for a Gemma3 tokenizer that is using unicode code points, unlike Tiktoken BPE.