### PR TITLE
Sentence piece tokenizer

### DIFF
--- a/documentation/reference/interpreter/tokens.rst
+++ b/documentation/reference/interpreter/tokens.rst
@@ -39,6 +39,13 @@ Byte pair encoder
 .. doxygenvariable:: metalchat::text::token::ipython
 
 
+Sentence Piece
+--------------
+
+.. doxygenclass:: metalchat::text::sentence_piece
+   :members:
+
+
 Regular expression
 ------------------
 

--- a/include/metalchat/huggingface/gemma.h
+++ b/include/metalchat/huggingface/gemma.h
@@ -89,7 +89,7 @@ private:
 
 
 struct gemma3_tokenizer_loader {
-    using type = text::byte_pair_encoder<char32_t>;
+    using type = text::sentence_piece;
 
     type
     load(std::istream& is) const;
@@ -109,7 +109,7 @@ template <contiguous_container Container> struct gemma3_traits {
     using options_type = nn::gemma3_options;
     using options_serializer = gemma3_options_serializer;
 
-    using tokenizer_type = text::byte_pair_encoder<char32_t>;
+    using tokenizer_type = text::sentence_piece;
     using tokenizer_loader = gemma3_tokenizer_loader;
 };
 

--- a/include/metalchat/nn/attention.h
+++ b/include/metalchat/nn/attention.h
@@ -261,6 +261,7 @@ permute_attention_heads(const Input& input, std::size_t n_heads, hardware_accele
 /// \tparam T a data type of the input tensor.
 /// \param ptr a pointer to the input tensor.
 /// \param n_heads a number of the attention heads in the input tensor.
+/// \param accelerator a hardware accelerator instance.
 template <typename T>
 void
 permute_attention_heads(

--- a/include/metalchat/text.h
+++ b/include/metalchat/text.h
@@ -7,3 +7,4 @@
 #include <metalchat/text/bpe.h>
 #include <metalchat/text/gpt.h>
 #include <metalchat/text/regexp.h>
+#include <metalchat/text/sentence_piece.h>

--- a/include/metalchat/text/bpe.h
+++ b/include/metalchat/text/bpe.h
@@ -211,7 +211,7 @@ public:
     ///
     /// \param is An input stream containing tokenizer model.
     /// \param token_regex A regular expression to split the input string into tokens.
-    byte_pair_encoder(std::istream& is, const string_type& token_regex)
+    byte_pair_encoder(std::basic_istream<CharT>& is, const string_type& token_regex)
     : byte_pair_encoder(token_regex)
     {
         string_type line;
@@ -352,7 +352,7 @@ public:
     ///
     /// Method at first attempts to find a token within a model token map, then tries to
     /// query special tokens. In token is not found, method raises an exception.
-    const string_type
+    string_type
     decode(index_type id) const
     {
         if (auto tok = _M_inverse_mapping.find(id); tok != _M_inverse_mapping.end()) {
@@ -383,7 +383,7 @@ public:
     decode(ForwardIt first, ForwardIt last) const
     {
         std::basic_stringstream<CharT> output;
-        decode(first, last, std::ostream_iterator<string_type>(output));
+        decode(first, last, std::ostream_iterator<string_type, CharT>(output));
         return output.str();
     }
 };

--- a/include/metalchat/text/sentence_piece.h
+++ b/include/metalchat/text/sentence_piece.h
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Yakau Bubnou
+// SPDX-FileType: SOURCE
+
+#pragma once
+
+#include <algorithm>
+
+#include <metalchat/text/bpe.h>
+
+
+namespace metalchat {
+namespace text {
+
+
+/// A tokenizer that applies byte-pair tokenizer directly on unicode text.
+class sentence_piece {
+public:
+    using char_type = char32_t;
+    using Tokenizer = byte_pair_encoder<char_type>;
+
+    using string_type = Tokenizer::string_type;
+    using index_type = Tokenizer::index_type;
+
+    /// The \ref sentence_piece copy constructor.
+    sentence_piece(const sentence_piece&) = default;
+
+    /// The \ref sentence_piece default constructor.
+    sentence_piece()
+    : _M_bpe(UR"(.*)")
+    {}
+
+    template <input_token_iterator_t<char_type> InputIt>
+    sentence_piece(InputIt first, InputIt last)
+    : _M_bpe(first, last, UR"(.*)")
+    {}
+
+    /// \copydoc byte_pair_encoder::insert
+    void
+    insert(const string_type& value, index_type key, tokenkind kind = token::regular)
+    {
+        _M_bpe.insert(value, key, kind);
+    }
+
+    /// \copydoc byte_pair_encoder::insert_back
+    void
+    insert_back(const string_type& value, tokenkind kind = token::regular)
+    {
+        _M_bpe.insert_back(value, kind);
+    }
+
+    /// \copydoc byte_pair_encoder::size
+    std::size_t
+    size() const
+    {
+        return _M_bpe.size();
+    }
+
+    /// Encode the provided string into tokens.
+    ///
+    /// The method replaces all white space characters with a special unicode symbols, and
+    /// then encodes the whole sequence using byte-pair encoding.
+    template <std::output_iterator<index_type> OutputIt>
+    void
+    encode(const string_type& s, OutputIt output) const
+    {
+        auto input = s;
+        std::replace(input.begin(), input.end(), whitespace_forward, whitespace_inverse);
+        _M_bpe.encode(input, output);
+    }
+
+    /// \copydoc byte_pair_encoder::encode(tokenkind) const
+    index_type
+    encode(tokenkind kind) const
+    {
+        return _M_bpe.encode(kind);
+    }
+
+    /// \copydoc byte_pair_encoder::encode(tokenkind, OutputIt) const
+    template <std::output_iterator<index_type> OutputIt>
+    void
+    encode(tokenkind kind, OutputIt output) const
+    {
+        _M_bpe.encode(kind, output);
+    }
+
+    /// Decode a single position-encoded token to the string representation.
+    ///
+    /// Method replaces all whitespace-replacement unicode code points with a unicode code
+    /// point of the regular white space.
+    string_type
+    decode(index_type id) const
+    {
+        auto s = _M_bpe.decode(id);
+        std::replace(s.begin(), s.end(), whitespace_inverse, whitespace_forward);
+        return s;
+    }
+
+    /// \copydoc byte_pair_encoder::decode(ForwardIt, ForwardIt, OutputIt) const
+    template <std::forward_iterator ForwardIt, std::output_iterator<std::string> OutputIt>
+    void
+    decode(ForwardIt first, ForwardIt last, OutputIt output) const
+    {
+        for (auto id = first; id != last; ++id) {
+            *output++ = decode(*id);
+        }
+    }
+
+    /// \copydoc byte_pair_encoder::decode(ForwardIt, ForwardIt) const
+    template <std::forward_iterator ForwardIt>
+    string_type
+    decode(ForwardIt first, ForwardIt last) const
+    {
+        std::basic_stringstream<char_type> output;
+        decode(first, last, std::ostream_iterator<string_type, char_type>(output));
+        return output.str();
+    }
+
+private:
+    static constexpr char_type whitespace_forward = U' ';
+    static constexpr char_type whitespace_inverse = U'▁';
+
+    Tokenizer _M_bpe;
+};
+
+
+} // namespace text
+} // namespace metalchat

--- a/src/gemma.cc
+++ b/src/gemma.cc
@@ -81,7 +81,7 @@ gemma3_tokenizer_loader::load(std::istream& is) const
 #pragma clang diagnostic pop
 
     auto model_file = jsoncons::decode_json<model_type>(is);
-    gemma3_tokenizer_loader::type tokenizer(UR"(.*)");
+    gemma3_tokenizer_loader::type tokenizer;
 
     for (const auto& [value, key] : model_file.model.vocab) {
         tokenizer.insert(convert.from_bytes(value), key, text::token::regular);

--- a/test/test_gemma.cc
+++ b/test/test_gemma.cc
@@ -28,7 +28,7 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
 
     std::vector<int32_t> ids;
     tokenizer.encode(text::token::begin_text, std::back_inserter(ids));
-    tokenizer.encode(UR"(I▁have▁a▁dog▁called)", std::back_inserter(ids));
+    tokenizer.encode(UR"(I have a dog called)", std::back_inserter(ids));
 
     auto transformer = repository.retrieve_transformer("model.safetensors", options);
 
@@ -40,8 +40,11 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
     auto input0 = shared_tensor(to_tensor<int32_t>({1, ids.size()}, ids.begin(), ids.end()));
     auto id = transformer.transform(input0);
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     using convert_type = std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t>;
     convert_type convert;
+#pragma clang diagnostic pop
 
     std::cout << "I have a dog called";
     std::cout << convert.to_bytes(tokenizer.decode(id.get()[0, 0]));


### PR DESCRIPTION
This patch implements sentence-piece tokenizer. It is wrapping the unicode-specialized BPE, and enforces processing of the whole input sequence instead of splitting it using a regular expression like in case of Tiktoken used in Llama.