### PR TITLE
Unicode tokenizer adaptor

### DIFF
--- a/include/metalchat/huggingface/gemma.h
+++ b/include/metalchat/huggingface/gemma.h
@@ -89,7 +89,7 @@ private:
 
 
 struct gemma3_tokenizer_loader {
-    using type = text::sentence_piece;
+    using type = text::unicode_tokenizer_adaptor<text::sentence_piece>;
 
     type
     load(std::istream& is) const;
@@ -109,7 +109,7 @@ template <contiguous_container Container> struct gemma3_traits {
     using options_type = nn::gemma3_options;
     using options_serializer = gemma3_options_serializer;
 
-    using tokenizer_type = text::sentence_piece;
+    using tokenizer_type = text::unicode_tokenizer_adaptor<text::sentence_piece>;
     using tokenizer_loader = gemma3_tokenizer_loader;
 };
 

--- a/include/metalchat/text.h
+++ b/include/metalchat/text.h
@@ -8,3 +8,4 @@
 #include <metalchat/text/gpt.h>
 #include <metalchat/text/regexp.h>
 #include <metalchat/text/sentence_piece.h>
+#include <metalchat/text/unicode_tokenizer.h>

--- a/include/metalchat/text/sentence_piece.h
+++ b/include/metalchat/text/sentence_piece.h
@@ -97,7 +97,7 @@ public:
     }
 
     /// \copydoc byte_pair_encoder::decode(ForwardIt, ForwardIt, OutputIt) const
-    template <std::forward_iterator ForwardIt, std::output_iterator<std::string> OutputIt>
+    template <std::forward_iterator ForwardIt, std::output_iterator<string_type> OutputIt>
     void
     decode(ForwardIt first, ForwardIt last, OutputIt output) const
     {

--- a/include/metalchat/text/unicode_tokenizer.h
+++ b/include/metalchat/text/unicode_tokenizer.h
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Yakau Bubnou
+// SPDX-FileType: SOURCE
+
+#pragma once
+
+#include <codecvt>
+#include <iterator>
+#include <locale>
+
+
+namespace metalchat {
+namespace text {
+
+
+template <typename Tokenizer> class unicode_tokenizer_adaptor : public Tokenizer {
+public:
+    using char_type = Tokenizer::char_type;
+    using index_type = Tokenizer::index_type;
+
+    using Tokenizer::decode;
+    using Tokenizer::encode;
+    using Tokenizer::Tokenizer;
+
+    /// The \ref unicode_tokenizer_adaptor copy constructor.
+    unicode_tokenizer_adaptor(const unicode_tokenizer_adaptor&) = default;
+
+    template <std::output_iterator<index_type> OutputIt>
+    void
+    encode(const std::string& s, OutputIt output) const
+    {
+        encode(decode_bytes<char_type>(s), output);
+    }
+
+    std::string
+    decode(index_type id) const
+    {
+        return encode_bytes(Tokenizer::decode(id));
+    }
+
+    template <std::forward_iterator ForwardIt, std::output_iterator<std::string> OutputIt>
+    void
+    decode(ForwardIt first, ForwardIt last, OutputIt output) const
+    {
+        for (auto id = first; id != last; ++id) {
+            *output++ = decode(*id);
+        }
+    }
+
+    template <std::forward_iterator ForwardIt>
+    std::string
+    decode(ForwardIt first, ForwardIt last) const
+    {
+        return encode_bytes(Tokenizer::decode(first, last));
+    }
+
+private:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    using codecvt_type = std::codecvt_utf8<char_type>;
+    using convert_type = std::wstring_convert<codecvt_type, char_type>;
+#pragma clang diagnostic pop
+
+    template <typename CharT>
+    static std::string
+    encode_bytes(const std::basic_string<CharT>& s)
+    {
+        convert_type convert;
+        return convert.to_bytes(s);
+    }
+
+    template <typename CharT>
+    static std::basic_string<CharT>
+    decode_bytes(const std::string& b)
+    {
+        convert_type convert;
+        return convert.from_bytes(b);
+    }
+};
+
+
+} // namespace text
+} // namespace metalchat

--- a/test/test_gemma.cc
+++ b/test/test_gemma.cc
@@ -28,7 +28,7 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
 
     std::vector<int32_t> ids;
     tokenizer.encode(text::token::begin_text, std::back_inserter(ids));
-    tokenizer.encode(UR"(I have a dog called)", std::back_inserter(ids));
+    tokenizer.encode("I have a dog called", std::back_inserter(ids));
 
     auto transformer = repository.retrieve_transformer("model.safetensors", options);
 
@@ -40,17 +40,11 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
     auto input0 = shared_tensor(to_tensor<int32_t>({1, ids.size()}, ids.begin(), ids.end()));
     auto id = transformer.transform(input0);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    using convert_type = std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t>;
-    convert_type convert;
-#pragma clang diagnostic pop
-
     std::cout << "I have a dog called";
-    std::cout << convert.to_bytes(tokenizer.decode(id.get()[0, 0]));
+    std::cout << tokenizer.decode(id.get()[0, 0]);
 
     for (std::size_t i = input0.size(1); i < 32; i++) {
         id = transformer.transform(id, i);
-        std::cout << convert.to_bytes(tokenizer.decode(id.get()[0, 0])) << std::flush;
+        std::cout << tokenizer.decode(id.get()[0, 0]) << std::flush;
     }
 }


### PR DESCRIPTION
An adaptor that performs conversion between utf-8 encoded string and utf-32 code points (or any other base tokenizer encodings). This is necessary to fit Gemma3 tokenizer to the same programming API as Llama tokenizer (Tiktoken BPE).