### PR TITLE
Introduce polymorphic tokenizer for the interpreter

### DIFF
--- a/include/metalchat/interpreter.h
+++ b/include/metalchat/interpreter.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// SPDX-FileCopyrightText: 2025 Yakau Bubnou
+// SPDX-FileCopyrightText: 2026 Yakau Bubnou
 // SPDX-FileType: SOURCE
 
 #pragma once
@@ -51,20 +51,170 @@ public:
         return _M_content;
     }
 
-    template <std::output_iterator<int32_t> OutputIt>
-    void
-    encode(const text::bpe& encoder, OutputIt output) const
-    {
-        encoder.encode(text::token::begin_header, output);
-        encoder.encode(_M_role, output);
-        encoder.encode(text::token::end_header, output);
-        encoder.encode("\n\n", output);
-        encoder.encode(_M_content, output);
-    }
-
 private:
     std::string _M_role;
     std::string _M_content;
+};
+
+
+struct basic_tokenizer {
+    template <typename T> struct basic_output_iterator {
+        using iterator_category = std::output_iterator_tag;
+        using value_type = void;
+        using pointer = void;
+        using reference = void;
+        using difference_type = std::ptrdiff_t;
+
+        virtual basic_output_iterator&
+        operator++()
+        {
+            return *this;
+        };
+
+        virtual basic_output_iterator&
+        operator++(int)
+        {
+            return *this;
+        }
+
+        virtual basic_output_iterator&
+        operator*()
+        {
+            return *this;
+        };
+
+        virtual basic_output_iterator&
+        operator=(const T&)
+        {
+            return *this;
+        };
+
+        virtual basic_output_iterator&
+        operator=(T&&)
+        {
+            return *this;
+        };
+
+        virtual ~basic_output_iterator() = default;
+    };
+
+    static_assert(std::output_iterator<basic_output_iterator<int>, int>);
+
+    template <typename T, std::output_iterator<T> OutputIt>
+    struct output_iterator_wrapper : public basic_output_iterator<T> {
+    private:
+        OutputIt* _M_it;
+
+    public:
+        using value_type = T;
+        using basic_type = basic_output_iterator<value_type>;
+
+        output_iterator_wrapper(OutputIt& output)
+        : _M_it(std::addressof(output))
+        {}
+
+        basic_type&
+        operator++() override
+        {
+            ++(*_M_it);
+            return *this;
+        }
+
+        basic_type&
+        operator++(int) override
+        {
+            ++(*_M_it);
+            return *this;
+        }
+
+        basic_type&
+        operator*() override
+        {
+            return *this;
+        }
+
+        basic_type&
+        operator=(const value_type& value) override
+        {
+            **_M_it = value;
+            return *this;
+        }
+
+        basic_type&
+        operator=(value_type&& value) override
+        {
+            **_M_it = std::move(value);
+            return *this;
+        }
+    };
+
+    using index_type = int32_t;
+    using string_type = std::string;
+    using output_iterator = basic_output_iterator<index_type>;
+
+    virtual std::string decode(index_type) const = 0;
+
+    virtual void
+    encode(text::tokenkind kind, output_iterator& output) const = 0;
+
+    template <std::output_iterator<index_type> OutputIt>
+    void
+    encode(text::tokenkind kind, OutputIt& output) const
+    {
+        using iterator = output_iterator_wrapper<index_type, OutputIt>;
+
+        iterator output_it(output);
+        encode(kind, output_it);
+    }
+
+    virtual void
+    encode(const string_type& s, output_iterator& output) const = 0;
+
+    template <std::output_iterator<index_type> OutputIt>
+    void
+    encode(const string_type& s, OutputIt& output) const
+    {
+        using iterator = output_iterator_wrapper<index_type, OutputIt>;
+
+        iterator output_it(output);
+        encode(s, output_it);
+    }
+
+    /// The \ref basic_tokenizer default destructor.
+    virtual ~basic_tokenizer() = default;
+};
+
+
+template <typename Tokenizer> class tokenizer_wrapper : public basic_tokenizer {
+public:
+    tokenizer_wrapper(Tokenizer&& encoder)
+    : _M_tokenizer(std::move(encoder))
+    {}
+
+    tokenizer_wrapper(const Tokenizer& encoder)
+    : _M_tokenizer(encoder)
+    {}
+
+    string_type
+    decode(index_type id) const
+    {
+        return _M_tokenizer.decode(id);
+    }
+
+    void
+    encode(text::tokenkind kind, output_iterator& output) const
+    {
+        return _M_tokenizer.encode(kind, output);
+    }
+
+    void
+    encode(const string_type& s, output_iterator& output) const
+    {
+        return _M_tokenizer.encode(s, output);
+    }
+
+private:
+    Tokenizer _M_tokenizer;
 };
 
 
@@ -78,8 +228,8 @@ public:
     virtual bool
     scan(index_type token) = 0;
 
-    /// The default /ref basic_token_scanner destructor.
-    virtual ~basic_token_scanner() {}
+    /// The /ref basic_token_scanner default destructor.
+    virtual ~basic_token_scanner() = default;
 };
 
 
@@ -197,9 +347,16 @@ private:
 
     template <typename Transformer>
     static std::shared_ptr<basic_transformer>
-    wrap(Transformer&& transformer)
+    polymorphic_cast_transformer(const Transformer& transformer)
     {
-        return std::make_shared<transformer_wrapper<Transformer>>(std::move(transformer));
+        return std::make_shared<transformer_wrapper<Transformer>>(transformer);
+    }
+
+    template <typename Tokenizer>
+    static std::shared_ptr<basic_tokenizer>
+    polymorphic_cast_tokenizer(const Tokenizer& tokenizer)
+    {
+        return std::make_shared<tokenizer_wrapper<Tokenizer>>(tokenizer);
     }
 
 public:
@@ -208,20 +365,14 @@ public:
     /// Interpreter executes a registered command, when an LLM model requests for an execution.
     using command_type = std::function<std::string(const command_statement&)>;
 
-    template <typename Transformer>
-    interpreter(Transformer&& transformer, const text::bpe& encoder, std::size_t max_pos = -1)
-    : interpreter(wrap(std::move(transformer)), encoder, max_pos)
-    {}
-
-    template <typename Transformer>
-    interpreter(const Transformer& transformer, const text::bpe& encoder, std::size_t max_pos = -1)
-    : interpreter(wrap(transformer), encoder, max_pos)
+    template <typename Transformer, typename Tokenizer>
+    interpreter(const Transformer& transformer, const Tokenizer& tokenizer)
+    : interpreter(polymorphic_cast_transformer(transformer), polymorphic_cast_tokenizer(tokenizer))
     {}
 
     interpreter(
         std::shared_ptr<basic_transformer> transformer_ptr,
-        const text::bpe& encoder,
-        std::size_t max_pos = -1
+        std::shared_ptr<basic_tokenizer> tokenizer_ptr
     );
 
     void
@@ -302,7 +453,7 @@ public:
 
     template <std::output_iterator<std::string> OutputIt>
     void
-    read(OutputIt output)
+    read(OutputIt& output)
     {
         write_header("assistant");
         read_until(output);
@@ -333,12 +484,11 @@ public:
 private:
     std::shared_ptr<_Members> _M_members;
     std::shared_ptr<basic_transformer> _M_transformer;
+    std::shared_ptr<basic_tokenizer> _M_tokenizer;
     std::shared_ptr<basic_token_scanner> _M_token_scanner;
     std::shared_ptr<basic_command_scanner> _M_command_scanner;
     std::unordered_map<std::string, command_type> _M_commands;
-    text::bpe _M_encoder;
 
-    std::size_t _M_max_pos;
     std::size_t _M_start_pos;
     std::vector<index_type> _M_buf;
 
@@ -353,7 +503,6 @@ private:
 
         auto encoding_size = encoding.size();
         auto container_ptr = std::make_shared<container_type>(std::move(encoding));
-
         auto accelerator = _M_transformer->accelerator();
         auto alloc = accelerator.get_allocator();
 
@@ -366,7 +515,7 @@ private:
 
     template <std::output_iterator<std::string> OutputIt>
     tensor_type
-    read_until(OutputIt it)
+    read_until(OutputIt& it)
     {
         _M_token_scanner->reset();
 
@@ -374,7 +523,7 @@ private:
         auto token = stream.get()[0, 0];
 
         while (_M_token_scanner->scan(token)) {
-            *it++ = _M_encoder.decode(token);
+            *it++ = _M_tokenizer->decode(token);
             stream = _M_transformer->transform(stream, _M_start_pos++);
             token = stream.get()[0, 0];
         }

--- a/include/metalchat/text/bpe.h
+++ b/include/metalchat/text/bpe.h
@@ -131,7 +131,7 @@ private:
     /// 4. Then push encodings to the specified container of identifiers.
     template <std::output_iterator<index_type> OutputIt>
     void
-    _M_encode_unicode_pairs(const string_type& s, OutputIt output) const
+    _M_encode_unicode_pairs(const string_type& s, OutputIt& output) const
     {
         std::size_t priority_limit = std::numeric_limits<index_type>::max();
 
@@ -302,7 +302,7 @@ public:
     /// appended to the end of the container.
     template <std::output_iterator<index_type> OutputIt>
     void
-    encode(const string_type& s, OutputIt output) const
+    encode(const string_type& s, OutputIt& output) const
     {
         for (auto match = _M_re->begin(s); match != _M_re->end(); ++match) {
             auto key = (*match);
@@ -335,7 +335,7 @@ public:
     /// Method encodes the provided special token and pushes the result to the output iterator.
     template <std::output_iterator<index_type> OutputIt>
     void
-    encode(tokenkind kind, OutputIt output) const
+    encode(tokenkind kind, OutputIt& output) const
     {
         *output++ = encode(kind);
     }
@@ -344,7 +344,8 @@ public:
     encode(const string_type& s) const
     {
         std::vector<index_type> output;
-        encode(s, std::back_inserter(output));
+        auto output_it = std::back_inserter(output);
+        encode(s, output_it);
         return to_tensor<index_type>({output.size()}, output.cbegin(), output.cend());
     }
 
@@ -368,7 +369,7 @@ public:
     /// decoded tokens before thrown exception are left in the container.
     template <std::forward_iterator ForwardIt, std::output_iterator<string_type> OutputIt>
     void
-    decode(ForwardIt first, ForwardIt last, OutputIt output) const
+    decode(ForwardIt first, ForwardIt last, OutputIt& output) const
     {
         for (auto id = first; id != last; ++id) {
             *output++ = decode(*id);
@@ -383,7 +384,8 @@ public:
     decode(ForwardIt first, ForwardIt last) const
     {
         std::basic_stringstream<CharT> output;
-        decode(first, last, std::ostream_iterator<string_type, CharT>(output));
+        std::ostream_iterator<string_type, CharT> output_it(output);
+        decode(first, last, output_it);
         return output.str();
     }
 };

--- a/include/metalchat/text/sentence_piece.h
+++ b/include/metalchat/text/sentence_piece.h
@@ -62,7 +62,7 @@ public:
     /// then encodes the whole sequence using byte-pair encoding.
     template <std::output_iterator<index_type> OutputIt>
     void
-    encode(const string_type& s, OutputIt output) const
+    encode(const string_type& s, OutputIt& output) const
     {
         auto input = s;
         std::replace(input.begin(), input.end(), whitespace_forward, whitespace_inverse);
@@ -79,7 +79,7 @@ public:
     /// \copydoc byte_pair_encoder::encode(tokenkind, OutputIt) const
     template <std::output_iterator<index_type> OutputIt>
     void
-    encode(tokenkind kind, OutputIt output) const
+    encode(tokenkind kind, OutputIt& output) const
     {
         _M_bpe.encode(kind, output);
     }
@@ -99,7 +99,7 @@ public:
     /// \copydoc byte_pair_encoder::decode(ForwardIt, ForwardIt, OutputIt) const
     template <std::forward_iterator ForwardIt, std::output_iterator<string_type> OutputIt>
     void
-    decode(ForwardIt first, ForwardIt last, OutputIt output) const
+    decode(ForwardIt first, ForwardIt last, OutputIt& output) const
     {
         for (auto id = first; id != last; ++id) {
             *output++ = decode(*id);

--- a/include/metalchat/text/unicode_tokenizer.h
+++ b/include/metalchat/text/unicode_tokenizer.h
@@ -27,7 +27,7 @@ public:
 
     template <std::output_iterator<index_type> OutputIt>
     void
-    encode(const std::string& s, OutputIt output) const
+    encode(const std::string& s, OutputIt& output) const
     {
         encode(decode_bytes<char_type>(s), output);
     }
@@ -40,7 +40,7 @@ public:
 
     template <std::forward_iterator ForwardIt, std::output_iterator<std::string> OutputIt>
     void
-    decode(ForwardIt first, ForwardIt last, OutputIt output) const
+    decode(ForwardIt first, ForwardIt last, OutputIt& output) const
     {
         for (auto id = first; id != last; ++id) {
             *output++ = decode(*id);

--- a/include/metalchat/transformer.h
+++ b/include/metalchat/transformer.h
@@ -253,11 +253,11 @@ public:
     using index_type = int32_t;
     using tensor_type = future_tensor<index_type, 2>;
 
-    virtual tensor_type
-    transform(tensor_type, std::size_t start_pos) = 0;
-
     virtual hardware_accelerator&
     accelerator() = 0;
+
+    virtual tensor_type
+    transform(tensor_type, std::size_t start_pos) = 0;
 };
 
 
@@ -280,7 +280,7 @@ public:
     hardware_accelerator&
     accelerator()
     {
-        return _M_transformer.get_layer().accelerator();
+        return _M_transformer.accelerator();
     }
 
 private:
@@ -308,6 +308,12 @@ public:
     : _M_layer(layer),
       _M_sampler(nn::make_default_sampler<value_type>())
     {}
+
+    hardware_accelerator&
+    accelerator()
+    {
+        return _M_layer.accelerator();
+    }
 
     /// Replace current sampler with the specified implementation.
     ///

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -69,19 +69,20 @@ struct interpreter::_Members {
 
 interpreter::interpreter(
     std::shared_ptr<basic_transformer> transformer_ptr,
-    const text::bpe& encoder,
-    std::size_t max_pos
+    std::shared_ptr<basic_tokenizer> tokenizer_ptr
 )
 : _M_members(std::make_shared<_Members>()),
   _M_transformer(transformer_ptr),
+  _M_tokenizer(tokenizer_ptr),
   _M_token_scanner(std::make_shared<limit_token_scanner>(50)),
   _M_command_scanner(std::make_shared<json_command_scanner>()),
   _M_commands(),
-  _M_encoder(encoder),
-  _M_max_pos(max_pos),
   _M_start_pos(0),
-  _M_buf(1, encoder.encode(text::token::begin_text))
+  _M_buf()
 {
+    auto output = std::back_inserter(_M_buf);
+    _M_tokenizer->encode(text::token::begin_text, output);
+
     // Do not escape characters, leave them as is. This is the global configuration,
     // so unfortunately this line changes behaviour for the whole library.
     mustache::config::escape = [](const std::string& str) -> std::string { return str; };
@@ -116,10 +117,10 @@ interpreter::write_header(const std::string& role)
 {
     auto output = std::back_inserter(_M_buf);
 
-    _M_encoder.encode(text::token::begin_header, output);
-    _M_encoder.encode(role, output);
-    _M_encoder.encode(text::token::end_header, output);
-    _M_encoder.encode("\n\n", output);
+    _M_tokenizer->encode(text::token::begin_header, output);
+    _M_tokenizer->encode(role, output);
+    _M_tokenizer->encode(text::token::end_header, output);
+    _M_tokenizer->encode("\n\n", output);
 }
 
 
@@ -130,8 +131,8 @@ interpreter::write(const basic_message& message)
 
     auto output = std::back_inserter(_M_buf);
     auto content = mustache::render(message.content(), _M_members->context());
-    _M_encoder.encode(content, output);
-    _M_encoder.encode(text::token::end_turn, output);
+    _M_tokenizer->encode(content, output);
+    _M_tokenizer->encode(text::token::end_turn, output);
 }
 
 

--- a/test/test_gemma.cc
+++ b/test/test_gemma.cc
@@ -26,9 +26,12 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
     auto options = repository.retrieve_options("config.json");
     auto tokenizer = repository.retrieve_tokenizer("tokenizer.json");
 
+    auto input_text = std::string("I have a dog called");
+
     std::vector<int32_t> ids;
-    tokenizer.encode(text::token::begin_text, std::back_inserter(ids));
-    tokenizer.encode("I have a dog called", std::back_inserter(ids));
+    auto output = std::back_inserter(ids);
+    tokenizer.encode(text::token::begin_text, output);
+    tokenizer.encode(input_text, output);
 
     auto transformer = repository.retrieve_transformer("model.safetensors", options);
 
@@ -40,7 +43,7 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
     auto input0 = shared_tensor(to_tensor<int32_t>({1, ids.size()}, ids.begin(), ids.end()));
     auto id = transformer.transform(input0);
 
-    std::cout << "I have a dog called";
+    std::cout << input_text;
     std::cout << tokenizer.decode(id.get()[0, 0]);
 
     for (std::size_t i = input0.size(1); i < 32; i++) {

--- a/test/test_interpreter.cc
+++ b/test/test_interpreter.cc
@@ -70,13 +70,16 @@ You have access to the following tools:
 )";
 
     interp.declare_variable("extra_instructions", "answer in json");
-    interp.declare_command(command, [](const command_statement&) -> std::string {
+    interp.declare_command(command, [](const command_statement& stmt) -> std::string {
+        CHECK(stmt.get_parameter("a").value() == R"("12135")");
+        CHECK(stmt.get_parameter("b").value() == R"("9312")");
         return R"(print 113001120)";
     });
     interp.write(basic_message("system", prompt));
     interp.write(basic_message("user", "What is 12135 multiplied by 9312?"));
 
-    std::cout << interp.exec().content() << std::endl;
+    auto result = interp.exec().content();
+    CHECK(result == "113001120");
 
     interp.write(basic_message("user", "what is the capital of Belgium?"));
     std::cout << interp.read_text() << std::endl;

--- a/test/test_llama.cc
+++ b/test/test_llama.cc
@@ -37,8 +37,10 @@ TEST_CASE("Test Llama3 implementation", "[llama][integration]")
     auto input_text = std::string("I have a dog called");
 
     std::vector<int32_t> ids;
-    tokenizer.encode(text::token::begin_text, std::back_inserter(ids));
-    tokenizer.encode(input_text, std::back_inserter(ids));
+    auto output = std::back_inserter(ids);
+    tokenizer.encode(text::token::begin_text, output);
+    tokenizer.encode(input_text, output);
+
 
     auto input0 = shared_tensor(to_tensor<int32_t>({1, ids.size()}, ids.begin(), ids.end()));
     auto id = transformer.transform(input0);

--- a/test/test_quantization.cc
+++ b/test/test_quantization.cc
@@ -79,8 +79,9 @@ TEST_CASE("Test QLoRA inference", "[quantization][integration]")
     auto input_text = std::string("I have a dog called");
 
     std::vector<int32_t> ids;
-    tokenizer.encode(text::token::begin_text, std::back_inserter(ids));
-    tokenizer.encode(input_text, std::back_inserter(ids));
+    auto output = std::back_inserter(ids);
+    tokenizer.encode(text::token::begin_text, output);
+    tokenizer.encode(input_text, output);
 
     auto input0 = shared_tensor(to_tensor<int32_t>({1, ids.size()}, ids.begin(), ids.end()));
     auto id = transformer.transform(input0);


### PR DESCRIPTION
This patch introduces a polymorphic tokenizer, so different tokenizers could be used within interpreter.