### PR TITLE
Tokenizer traits

### DIFF
--- a/include/metalchat/interpreter.h
+++ b/include/metalchat/interpreter.h
@@ -57,167 +57,6 @@ private:
 };
 
 
-struct basic_tokenizer {
-    template <typename T> struct basic_output_iterator {
-        using iterator_category = std::output_iterator_tag;
-        using value_type = void;
-        using pointer = void;
-        using reference = void;
-        using difference_type = std::ptrdiff_t;
-
-        virtual basic_output_iterator&
-        operator++()
-        {
-            return *this;
-        };
-
-        virtual basic_output_iterator&
-        operator++(int)
-        {
-            return *this;
-        }
-
-        virtual basic_output_iterator&
-        operator*()
-        {
-            return *this;
-        };
-
-        virtual basic_output_iterator&
-        operator=(const T&)
-        {
-            return *this;
-        };
-
-        virtual basic_output_iterator&
-        operator=(T&&)
-        {
-            return *this;
-        };
-
-        virtual ~basic_output_iterator() = default;
-    };
-
-    static_assert(std::output_iterator<basic_output_iterator<int>, int>);
-
-    template <typename T, std::output_iterator<T> OutputIt>
-    struct output_iterator_wrapper : public basic_output_iterator<T> {
-    private:
-        OutputIt* _M_it;
-
-    public:
-        using value_type = T;
-        using basic_type = basic_output_iterator<value_type>;
-
-        output_iterator_wrapper(OutputIt& output)
-        : _M_it(std::addressof(output))
-        {}
-
-        basic_type&
-        operator++() override
-        {
-            ++(*_M_it);
-            return *this;
-        }
-
-        basic_type&
-        operator++(int) override
-        {
-            ++(*_M_it);
-            return *this;
-        }
-
-        basic_type&
-        operator*() override
-        {
-            return *this;
-        }
-
-        basic_type&
-        operator=(const value_type& value) override
-        {
-            **_M_it = value;
-            return *this;
-        }
-
-        basic_type&
-        operator=(value_type&& value) override
-        {
-            **_M_it = std::move(value);
-            return *this;
-        }
-    };
-
-    using index_type = int32_t;
-    using string_type = std::string;
-    using output_iterator = basic_output_iterator<index_type>;
-
-    virtual std::string decode(index_type) const = 0;
-
-    virtual void
-    encode(text::tokenkind kind, output_iterator& output) const = 0;
-
-    template <std::output_iterator<index_type> OutputIt>
-    void
-    encode(text::tokenkind kind, OutputIt& output) const
-    {
-        using iterator = output_iterator_wrapper<index_type, OutputIt>;
-
-        iterator output_it(output);
-        encode(kind, output_it);
-    }
-
-    virtual void
-    encode(const string_type& s, output_iterator& output) const = 0;
-
-    template <std::output_iterator<index_type> OutputIt>
-    void
-    encode(const string_type& s, OutputIt& output) const
-    {
-        using iterator = output_iterator_wrapper<index_type, OutputIt>;
-
-        iterator output_it(output);
-        encode(s, output_it);
-    }
-
-    /// The \ref basic_tokenizer default destructor.
-    virtual ~basic_tokenizer() = default;
-};
-
-
-template <typename Tokenizer> class tokenizer_wrapper : public basic_tokenizer {
-public:
-    tokenizer_wrapper(Tokenizer&& encoder)
-    : _M_tokenizer(std::move(encoder))
-    {}
-
-    tokenizer_wrapper(const Tokenizer& encoder)
-    : _M_tokenizer(encoder)
-    {}
-
-    string_type
-    decode(index_type id) const
-    {
-        return _M_tokenizer.decode(id);
-    }
-
-    void
-    encode(text::tokenkind kind, output_iterator& output) const
-    {
-        return _M_tokenizer.encode(kind, output);
-    }
-
-    void
-    encode(const string_type& s, output_iterator& output) const
-    {
-        return _M_tokenizer.encode(s, output);
-    }
-
-private:
-    Tokenizer _M_tokenizer;
-};
-
-
 class basic_token_scanner {
 public:
     using index_type = int32_t;
@@ -345,6 +184,9 @@ private:
     using tensor_type = future_tensor<index_type, 2>;
     using container_type = vector_memory_container<index_type>;
 
+    using tokenizer_type = text::basic_tokenizer<index_type, char>;
+    using tokenizer_traits = text::tokenizer_traits<tokenizer_type>;
+
     template <typename Transformer>
     static std::shared_ptr<basic_transformer>
     polymorphic_cast_transformer(const Transformer& transformer)
@@ -353,10 +195,10 @@ private:
     }
 
     template <typename Tokenizer>
-    static std::shared_ptr<basic_tokenizer>
+    static std::shared_ptr<tokenizer_type>
     polymorphic_cast_tokenizer(const Tokenizer& tokenizer)
     {
-        return std::make_shared<tokenizer_wrapper<Tokenizer>>(tokenizer);
+        return std::make_shared<text::tokenizer_wrapper<Tokenizer>>(tokenizer);
     }
 
 public:
@@ -372,7 +214,7 @@ public:
 
     interpreter(
         std::shared_ptr<basic_transformer> transformer_ptr,
-        std::shared_ptr<basic_tokenizer> tokenizer_ptr
+        std::shared_ptr<tokenizer_type> tokenizer_ptr
     );
 
     void
@@ -484,7 +326,7 @@ public:
 private:
     std::shared_ptr<_Members> _M_members;
     std::shared_ptr<basic_transformer> _M_transformer;
-    std::shared_ptr<basic_tokenizer> _M_tokenizer;
+    std::shared_ptr<tokenizer_type> _M_tokenizer;
     std::shared_ptr<basic_token_scanner> _M_token_scanner;
     std::shared_ptr<basic_command_scanner> _M_command_scanner;
     std::unordered_map<std::string, command_type> _M_commands;
@@ -523,7 +365,7 @@ private:
         auto token = stream.get()[0, 0];
 
         while (_M_token_scanner->scan(token)) {
-            *it++ = _M_tokenizer->decode(token);
+            tokenizer_traits::decode(*_M_tokenizer, token, it);
             stream = _M_transformer->transform(stream, _M_start_pos++);
             token = stream.get()[0, 0];
         }

--- a/include/metalchat/text.h
+++ b/include/metalchat/text.h
@@ -8,4 +8,5 @@
 #include <metalchat/text/gpt.h>
 #include <metalchat/text/regexp.h>
 #include <metalchat/text/sentence_piece.h>
+#include <metalchat/text/tokenizer.h>
 #include <metalchat/text/unicode_tokenizer.h>

--- a/include/metalchat/text/bpe.h
+++ b/include/metalchat/text/bpe.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// SPDX-FileCopyrightText: 2025 Yakau Bubnou
+// SPDX-FileCopyrightText: 2026 Yakau Bubnou
 // SPDX-FileType: SOURCE
 
 #pragma once
@@ -13,41 +13,17 @@
 #include <iterator>
 #include <memory>
 #include <queue>
-#include <sstream>
 #include <string>
 #include <tuple>
 #include <unordered_map>
 #include <vector>
 
-#include <metalchat/container.h>
-#include <metalchat/tensor.h>
 #include <metalchat/text/regexp.h>
+#include <metalchat/text/tokenizer.h>
 
 
 namespace metalchat {
 namespace text {
-
-
-/// Specifies kind of the token.
-///
-/// Tokens are used to transform a natural language sentences into a vector of integers
-/// mapping them to a embedding space of the respective language model. There are specific
-/// kinds of tokens that allow to instruct the model for a specific behaviour.
-using tokenkind = int32_t;
-
-
-struct token {
-    static constexpr tokenkind regular = 1 << 0;
-    static constexpr tokenkind begin_text = 1 << 1;
-    static constexpr tokenkind end_text = 1 << 2;
-    static constexpr tokenkind reserved = 1 << 3;
-    static constexpr tokenkind finetune_right_pad = 1 << 4;
-    static constexpr tokenkind begin_header = 1 << 5;
-    static constexpr tokenkind end_header = 1 << 6;
-    static constexpr tokenkind end_message = 1 << 7;
-    static constexpr tokenkind end_turn = 1 << 8;
-    static constexpr tokenkind ipython = 1 << 9;
-};
 
 
 /// Returns a reserved token string representation for the specified index.
@@ -88,9 +64,12 @@ concept input_token_iterator_t = requires {
 /// ```cpp
 /// using namespace metalchat::text;
 ///
-/// byte_pair_encoder<char> tokenizer("tokenizer.model");
-/// auto tokens = tokenizer.encode("This is a test sentence.");
-/// auto string = tokenizer.decode(tokens.begin(), tokens.end());
+/// using Tokenizer = byte_pair_encoder<char>;
+/// using TokenizerTraits = tokenizer_traits<Tokenizer>;
+///
+/// Tokenizer tokenizer("tokenizer.model");
+/// auto tokens = TokenizerTraits::encode(tokenizer, "This is a test sentence.");
+/// auto string = TokenizerTraits::decode(tokenizer, tokens.begin(), tokens.end());
 ///
 /// std::cout << string << std::endl;
 /// // output: This is a test sentence.
@@ -98,10 +77,13 @@ concept input_token_iterator_t = requires {
 template <typename CharT, typename RegularExpression = unicode_regexp<CharT>>
 class byte_pair_encoder {
 public:
+    /// Type used to indicate position of the token in the model (token dictionary).
+    using char_type = CharT;
+    using index_type = int32_t;
     using string_type = std::basic_string<CharT>;
 
-    /// Type used to indicate position of the token in the model (token dictionary).
-    using index_type = int32_t;
+    using encoding_iterator = basic_output_iterator<index_type>;
+    using decoding_iterator = basic_output_iterator<string_type>;
 
 private:
     std::unordered_map<string_type, index_type, _StringHash> _M_forward_mapping;
@@ -187,7 +169,8 @@ private:
 
         for (auto& e : encoding) {
             if (e.priority < priority_limit) {
-                *output++ = e.priority;
+                *output = e.priority;
+                ++output;
             }
         }
     }
@@ -300,14 +283,14 @@ public:
     /// token index into end of the provided iterator `output`. When the token is not presented
     /// in the token dictionary, it is divided into byte-pairs, then index of the byte pair is
     /// appended to the end of the container.
-    template <std::output_iterator<index_type> OutputIt>
     void
-    encode(const string_type& s, OutputIt& output) const
+    encode(const string_type& s, encoding_iterator& output) const
     {
         for (auto match = _M_re->begin(s); match != _M_re->end(); ++match) {
             auto key = (*match);
             if (auto it = _M_forward_mapping.find(key); it != _M_forward_mapping.end()) {
-                *output++ = it->second;
+                *output = it->second;
+                ++output;
             } else {
                 _M_encode_unicode_pairs(key, output);
             }
@@ -319,11 +302,13 @@ public:
     /// Method returns a position of a special token within a tokenizer model. When a token is
     /// a `token::regular` kind, then method raises an exception. Regular token encoding is
     /// available through \ref encode(const string_type&, OutputIt) const method.
-    index_type
-    encode(tokenkind kind) const
+    void
+    encode(tokenkind kind, encoding_iterator& output) const
     {
         if (auto it = _M_control_mapping.find(kind); it != _M_control_mapping.end()) {
-            return it->second;
+            *output = it->second;
+            ++output;
+            return;
         }
         throw std::invalid_argument(
             std::format("byte_pair_encoder: unknown control token '{}'", kind)
@@ -337,56 +322,23 @@ public:
     void
     encode(tokenkind kind, OutputIt& output) const
     {
-        *output++ = encode(kind);
-    }
-
-    auto
-    encode(const string_type& s) const
-    {
-        std::vector<index_type> output;
-        auto output_it = std::back_inserter(output);
-        encode(s, output_it);
-        return to_tensor<index_type>({output.size()}, output.cbegin(), output.cend());
+        *output = encode(kind);
+        ++output;
     }
 
     /// Decode a single position-encoded token to the string representation.
     ///
     /// Method at first attempts to find a token within a model token map, then tries to
     /// query special tokens. In token is not found, method raises an exception.
-    string_type
-    decode(index_type id) const
+    void
+    decode(index_type id, decoding_iterator& output) const
     {
         if (auto tok = _M_inverse_mapping.find(id); tok != _M_inverse_mapping.end()) {
-            return tok->second;
+            *output = tok->second;
+            ++output;
+            return;
         }
         throw std::runtime_error(std::format("byte_pair_encoder: unable to decode id '{}'", id));
-    }
-
-    /// Iteratively decode a sequence of position-encoded tokens.
-    ///
-    /// The result of decoding is sequentially appended to the specified container. If one
-    /// of the tokens is not decoded correctly, an exception is raised. All successfully
-    /// decoded tokens before thrown exception are left in the container.
-    template <std::forward_iterator ForwardIt, std::output_iterator<string_type> OutputIt>
-    void
-    decode(ForwardIt first, ForwardIt last, OutputIt& output) const
-    {
-        for (auto id = first; id != last; ++id) {
-            *output++ = decode(*id);
-        }
-    }
-
-    /// Iteratively decode a sequence of position-encoded tokens.
-    ///
-    /// All decoded tokens will be concatenated into a resulting string.
-    template <std::forward_iterator ForwardIt>
-    string_type
-    decode(ForwardIt first, ForwardIt last) const
-    {
-        std::basic_stringstream<CharT> output;
-        std::ostream_iterator<string_type, CharT> output_it(output);
-        decode(first, last, output_it);
-        return output.str();
     }
 };
 

--- a/include/metalchat/text/sentence_piece.h
+++ b/include/metalchat/text/sentence_piece.h
@@ -22,6 +22,9 @@ public:
     using string_type = Tokenizer::string_type;
     using index_type = Tokenizer::index_type;
 
+    using encoding_iterator = basic_output_iterator<index_type>;
+    using decoding_iterator = basic_output_iterator<string_type>;
+
     /// The \ref sentence_piece copy constructor.
     sentence_piece(const sentence_piece&) = default;
 
@@ -60,26 +63,17 @@ public:
     ///
     /// The method replaces all white space characters with a special unicode symbols, and
     /// then encodes the whole sequence using byte-pair encoding.
-    template <std::output_iterator<index_type> OutputIt>
     void
-    encode(const string_type& s, OutputIt& output) const
+    encode(const string_type& s, encoding_iterator& output) const
     {
         auto input = s;
         std::replace(input.begin(), input.end(), whitespace_forward, whitespace_inverse);
         _M_bpe.encode(input, output);
     }
 
-    /// \copydoc byte_pair_encoder::encode(tokenkind) const
-    index_type
-    encode(tokenkind kind) const
-    {
-        return _M_bpe.encode(kind);
-    }
-
     /// \copydoc byte_pair_encoder::encode(tokenkind, OutputIt) const
-    template <std::output_iterator<index_type> OutputIt>
     void
-    encode(tokenkind kind, OutputIt& output) const
+    encode(tokenkind kind, encoding_iterator& output) const
     {
         _M_bpe.encode(kind, output);
     }
@@ -88,32 +82,20 @@ public:
     ///
     /// Method replaces all whitespace-replacement unicode code points with a unicode code
     /// point of the regular white space.
-    string_type
-    decode(index_type id) const
-    {
-        auto s = _M_bpe.decode(id);
-        std::replace(s.begin(), s.end(), whitespace_inverse, whitespace_forward);
-        return s;
-    }
-
-    /// \copydoc byte_pair_encoder::decode(ForwardIt, ForwardIt, OutputIt) const
-    template <std::forward_iterator ForwardIt, std::output_iterator<string_type> OutputIt>
     void
-    decode(ForwardIt first, ForwardIt last, OutputIt& output) const
+    decode(index_type id, decoding_iterator& output) const
     {
-        for (auto id = first; id != last; ++id) {
-            *output++ = decode(*id);
-        }
-    }
+        using iterator = string_type*;
+        using iterator_wrapper = output_iterator_wrapper<string_type, iterator>;
 
-    /// \copydoc byte_pair_encoder::decode(ForwardIt, ForwardIt) const
-    template <std::forward_iterator ForwardIt>
-    string_type
-    decode(ForwardIt first, ForwardIt last) const
-    {
-        std::basic_stringstream<char_type> output;
-        decode(first, last, std::ostream_iterator<string_type, char_type>(output));
-        return output.str();
+        string_type s;
+        string_type* s_ptr = &s;
+        iterator_wrapper output_it(s_ptr);
+
+        _M_bpe.decode(id, output_it);
+        std::replace(s.begin(), s.end(), whitespace_inverse, whitespace_forward);
+        *output = s;
+        ++output;
     }
 
 private:

--- a/include/metalchat/text/tokenizer.h
+++ b/include/metalchat/text/tokenizer.h
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Yakau Bubnou
+// SPDX-FileType: SOURCE
+
+#pragma once
+
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <metalchat/container.h>
+#include <metalchat/tensor.h>
+
+
+namespace metalchat {
+namespace text {
+
+
+/// Specifies kind of the token.
+///
+/// Tokens are used to transform a natural language sentences into a vector of integers
+/// mapping them to a embedding space of the respective language model. There are specific
+/// kinds of tokens that allow to instruct the model for a specific behaviour.
+using tokenkind = int32_t;
+
+
+struct token {
+    static constexpr tokenkind regular = 1 << 0;
+    static constexpr tokenkind begin_text = 1 << 1;
+    static constexpr tokenkind end_text = 1 << 2;
+    static constexpr tokenkind reserved = 1 << 3;
+    static constexpr tokenkind finetune_right_pad = 1 << 4;
+    static constexpr tokenkind begin_header = 1 << 5;
+    static constexpr tokenkind end_header = 1 << 6;
+    static constexpr tokenkind end_message = 1 << 7;
+    static constexpr tokenkind end_turn = 1 << 8;
+    static constexpr tokenkind ipython = 1 << 9;
+};
+
+template <typename T> struct basic_output_iterator {
+    using iterator_category = std::output_iterator_tag;
+    using value_type = void;
+    using pointer = void;
+    using reference = void;
+    using difference_type = std::ptrdiff_t;
+
+    virtual basic_output_iterator&
+    operator++()
+    {
+        return *this;
+    };
+
+    basic_output_iterator
+    operator++(int)
+    {
+        throw std::runtime_error("basic_output_iterator: no use");
+    }
+
+    virtual basic_output_iterator&
+    operator*()
+    {
+        return *this;
+    };
+
+    virtual basic_output_iterator&
+    operator=(const T&)
+    {
+        return *this;
+    };
+
+    virtual basic_output_iterator&
+    operator=(T&&)
+    {
+        return *this;
+    };
+
+    virtual ~basic_output_iterator() = default;
+};
+
+
+template <typename T, std::output_iterator<T> OutputIt>
+struct output_iterator_wrapper : public basic_output_iterator<T> {
+private:
+    OutputIt* _M_it;
+
+public:
+    using value_type = T;
+    using basic_type = basic_output_iterator<value_type>;
+
+    output_iterator_wrapper(OutputIt& output)
+    : _M_it(std::addressof(output))
+    {}
+
+    output_iterator_wrapper(OutputIt* output_ptr)
+    : _M_it(output_ptr)
+    {}
+
+    basic_type&
+    operator++() override
+    {
+        ++(*_M_it);
+        return *this;
+    }
+
+    basic_type&
+    operator*() override
+    {
+        return *this;
+    }
+
+    basic_type&
+    operator=(const value_type& value) override
+    {
+        **_M_it = value;
+        return *this;
+    }
+
+    basic_type&
+    operator=(value_type&& value) override
+    {
+        **_M_it = std::move(value);
+        return *this;
+    }
+};
+
+
+template <typename Index, typename CharT> struct basic_tokenizer {
+    using index_type = Index;
+    using string_type = std::basic_string<CharT>;
+    using encoding_iterator = basic_output_iterator<index_type>;
+    using decoding_iterator = basic_output_iterator<string_type>;
+
+    virtual void
+    encode(tokenkind kind, encoding_iterator& output) const = 0;
+
+    virtual void
+    encode(const string_type& s, encoding_iterator& output) const = 0;
+
+    virtual void
+    decode(index_type id, decoding_iterator& output) const = 0;
+
+    /// The \ref basic_tokenizer default destructor.
+    virtual ~basic_tokenizer() = default;
+};
+
+
+template <typename I, typename T>
+concept forward_iterator = std::forward_iterator<I> && std::same_as<std::iter_value_t<I>, T>;
+
+
+template <typename Tokenizer> struct tokenizer_traits {
+    using index_type = Tokenizer::index_type;
+    using string_type = Tokenizer::string_type;
+    using char_type = string_type::value_type;
+    using encoding_iterator = Tokenizer::encoding_iterator;
+    using decoding_iterator = Tokenizer::decoding_iterator;
+
+    template <std::output_iterator<index_type> OutputIt>
+    static void
+    encode(const Tokenizer& t, const string_type& s, OutputIt& output)
+    {
+        using iterator_wrapper = output_iterator_wrapper<index_type, OutputIt>;
+        iterator_wrapper output_it(output);
+        t.encode(s, output_it);
+    }
+
+    template <std::output_iterator<index_type> OutputIt>
+    static void
+    encode(const Tokenizer& t, tokenkind kind, OutputIt& output)
+    {
+        using iterator_wrapper = output_iterator_wrapper<index_type, OutputIt>;
+        iterator_wrapper output_it(output);
+        t.encode(kind, output_it);
+    }
+
+    static index_type
+    encode(const Tokenizer& t, tokenkind kind)
+    {
+        using iterator = index_type*;
+        using iterator_wrapper = output_iterator_wrapper<index_type, iterator>;
+
+        index_type id;
+        index_type* id_ptr = &id;
+        iterator_wrapper output_it(id_ptr);
+
+        t.encode(kind, output_it);
+        return id;
+    }
+
+    static auto
+    encode(const Tokenizer& t, const string_type& s)
+    {
+        using container_type = vector_memory_container<index_type>;
+        using storage_type = container_type::storage_type;
+
+        storage_type output;
+        auto output_it = std::back_inserter(output);
+        encode(t, s, output_it);
+
+        auto container_size = output.size();
+        auto container_ptr = std::make_shared<container_type>(std::move(output));
+
+        return tensor({container_size}, container_ptr);
+    }
+
+    /// Iteratively decode a sequence of position-encoded tokens.
+    ///
+    /// The result of decoding is sequentially appended to the specified container. If one
+    /// of the tokens is not decoded correctly, an exception is raised. All successfully
+    /// decoded tokens before thrown exception are left in the container.
+    template <forward_iterator<index_type> ForwardIt, std::output_iterator<string_type> OutputIt>
+    static void
+    decode(const Tokenizer& t, ForwardIt first, ForwardIt last, OutputIt& output)
+    {
+        using iterator_wrapper = output_iterator_wrapper<string_type, OutputIt>;
+        iterator_wrapper output_it(output);
+
+        for (auto id = first; id != last; ++id) {
+            t.decode(*id, output_it);
+        }
+    }
+
+    template <std::output_iterator<string_type> OutputIt>
+    static void
+    decode(const Tokenizer& t, index_type id, OutputIt& output)
+    {
+        decode(t, &id, &id + 1, output);
+    }
+
+    /// Iteratively decode a sequence of position-encoded tokens.
+    ///
+    /// All decoded tokens will be concatenated into a resulting string.
+    template <forward_iterator<index_type> ForwardIt>
+    static string_type
+    decode(const Tokenizer& t, ForwardIt first, ForwardIt last)
+    {
+        std::basic_stringstream<char_type> output;
+        std::ostream_iterator<string_type, char_type> output_it(output);
+
+        decode(t, first, last, output_it);
+        return output.str();
+    }
+
+    static string_type
+    decode(const Tokenizer& t, index_type id)
+    {
+        return decode(t, &id, &id + 1);
+    }
+};
+
+
+template <typename Tokenizer>
+class tokenizer_wrapper
+: public basic_tokenizer<typename Tokenizer::index_type, typename Tokenizer::char_type> {
+private:
+public:
+    using char_type = Tokenizer::char_type;
+    using index_type = Tokenizer::index_type;
+    using string_type = Tokenizer::string_type;
+    using encoding_iterator = Tokenizer::encoding_iterator;
+    using decoding_iterator = Tokenizer::decoding_iterator;
+
+    tokenizer_wrapper(Tokenizer&& t)
+    : _M_tokenizer(std::move(t))
+    {}
+
+    tokenizer_wrapper(const Tokenizer& t)
+    : _M_tokenizer(t)
+    {}
+
+    void
+    encode(tokenkind kind, encoding_iterator& output) const
+    {
+        return _M_tokenizer.encode(kind, output);
+    }
+
+    void
+    encode(const string_type& s, encoding_iterator& output) const
+    {
+        return _M_tokenizer.encode(s, output);
+    }
+
+    void
+    decode(index_type id, decoding_iterator& output) const
+    {
+        _M_tokenizer.decode(id, output);
+    }
+
+
+private:
+    Tokenizer _M_tokenizer;
+};
+
+
+} // namespace text
+} // namespace metalchat

--- a/include/metalchat/text/unicode_tokenizer.h
+++ b/include/metalchat/text/unicode_tokenizer.h
@@ -15,63 +15,63 @@ namespace text {
 
 template <typename Tokenizer> class unicode_tokenizer_adaptor : public Tokenizer {
 public:
-    using char_type = Tokenizer::char_type;
+    using char_type = char;
     using index_type = Tokenizer::index_type;
+    using string_type = std::string;
 
-    using Tokenizer::decode;
-    using Tokenizer::encode;
+    using encoding_iterator = basic_output_iterator<index_type>;
+    using decoding_iterator = basic_output_iterator<string_type>;
+
     using Tokenizer::Tokenizer;
 
     /// The \ref unicode_tokenizer_adaptor copy constructor.
     unicode_tokenizer_adaptor(const unicode_tokenizer_adaptor&) = default;
 
-    template <std::output_iterator<index_type> OutputIt>
     void
-    encode(const std::string& s, OutputIt& output) const
+    encode(const string_type& s, encoding_iterator& output) const
     {
-        encode(decode_bytes<char_type>(s), output);
+        Tokenizer::encode(decode_bytes(s), output);
     }
 
-    std::string
-    decode(index_type id) const
-    {
-        return encode_bytes(Tokenizer::decode(id));
-    }
-
-    template <std::forward_iterator ForwardIt, std::output_iterator<std::string> OutputIt>
     void
-    decode(ForwardIt first, ForwardIt last, OutputIt& output) const
+    encode(tokenkind kind, encoding_iterator& output) const
     {
-        for (auto id = first; id != last; ++id) {
-            *output++ = decode(*id);
-        }
+        Tokenizer::encode(kind, output);
     }
 
-    template <std::forward_iterator ForwardIt>
-    std::string
-    decode(ForwardIt first, ForwardIt last) const
+    void
+    decode(index_type id, decoding_iterator& output) const
     {
-        return encode_bytes(Tokenizer::decode(first, last));
+        using value_type = Tokenizer::string_type;
+        using iterator = value_type*;
+        using iterator_wrapper = output_iterator_wrapper<value_type, iterator>;
+
+        value_type s;
+        value_type* s_ptr = &s;
+        iterator_wrapper output_it(s_ptr);
+
+        Tokenizer::decode(id, output_it);
+        *output = encode_bytes(s);
+        ++output;
     }
 
 private:
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    using codecvt_type = std::codecvt_utf8<char_type>;
-    using convert_type = std::wstring_convert<codecvt_type, char_type>;
+    using rune_type = Tokenizer::char_type;
+    using codecvt_type = std::codecvt_utf8<rune_type>;
+    using convert_type = std::wstring_convert<codecvt_type, rune_type>;
 #pragma clang diagnostic pop
 
-    template <typename CharT>
-    static std::string
-    encode_bytes(const std::basic_string<CharT>& s)
+    static string_type
+    encode_bytes(const std::basic_string<rune_type>& s)
     {
         convert_type convert;
         return convert.to_bytes(s);
     }
 
-    template <typename CharT>
-    static std::basic_string<CharT>
-    decode_bytes(const std::string& b)
+    static std::basic_string<rune_type>
+    decode_bytes(const string_type& b)
     {
         convert_type convert;
         return convert.from_bytes(b);

--- a/program/program.cc
+++ b/program/program.cc
@@ -97,11 +97,15 @@ program::transform(const program_scope& scope, const std::string& prompt) const
     auto transformer = repo.retrieve_transformer();
     auto tokenizer = repo.retrieve_tokenizer();
 
+    using Tokenizer = decltype(tokenizer);
+    using TokenizerTraits = text::tokenizer_traits<Tokenizer>;
+
     auto interp = metalchat::interpreter(transformer, tokenizer);
     // TODO: extract terminal tokens from the huggingface tokenizer configuration.
     interp.set_token_scanner(match_token_scanner(
-        {tokenizer.encode(text::token::end_text), tokenizer.encode(text::token::end_turn),
-         tokenizer.encode(text::token::end_message)}
+        {TokenizerTraits::encode(tokenizer, text::token::end_text),
+         TokenizerTraits::encode(tokenizer, text::token::end_turn),
+         TokenizerTraits::encode(tokenizer, text::token::end_message)}
     ));
 
     auto system_prompt = scope.manifest.system_prompt(scope.path);

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -69,7 +69,7 @@ struct interpreter::_Members {
 
 interpreter::interpreter(
     std::shared_ptr<basic_transformer> transformer_ptr,
-    std::shared_ptr<basic_tokenizer> tokenizer_ptr
+    std::shared_ptr<tokenizer_type> tokenizer_ptr
 )
 : _M_members(std::make_shared<_Members>()),
   _M_transformer(transformer_ptr),
@@ -81,7 +81,7 @@ interpreter::interpreter(
   _M_buf()
 {
     auto output = std::back_inserter(_M_buf);
-    _M_tokenizer->encode(text::token::begin_text, output);
+    tokenizer_traits::encode(*_M_tokenizer, text::token::begin_text, output);
 
     // Do not escape characters, leave them as is. This is the global configuration,
     // so unfortunately this line changes behaviour for the whole library.
@@ -117,10 +117,10 @@ interpreter::write_header(const std::string& role)
 {
     auto output = std::back_inserter(_M_buf);
 
-    _M_tokenizer->encode(text::token::begin_header, output);
-    _M_tokenizer->encode(role, output);
-    _M_tokenizer->encode(text::token::end_header, output);
-    _M_tokenizer->encode("\n\n", output);
+    tokenizer_traits::encode(*_M_tokenizer, text::token::begin_header, output);
+    tokenizer_traits::encode(*_M_tokenizer, role, output);
+    tokenizer_traits::encode(*_M_tokenizer, text::token::end_header, output);
+    tokenizer_traits::encode(*_M_tokenizer, "\n\n", output);
 }
 
 
@@ -131,8 +131,8 @@ interpreter::write(const basic_message& message)
 
     auto output = std::back_inserter(_M_buf);
     auto content = mustache::render(message.content(), _M_members->context());
-    _M_tokenizer->encode(content, output);
-    _M_tokenizer->encode(text::token::end_turn, output);
+    tokenizer_traits::encode(*_M_tokenizer, content, output);
+    tokenizer_traits::encode(*_M_tokenizer, text::token::end_turn, output);
 }
 
 

--- a/test/test_bpe.cc
+++ b/test/test_bpe.cc
@@ -37,9 +37,11 @@ TEST_CASE("Test GPT-2 codec", "[gpt2]")
 TEST_CASE("TEST GPT-2 to Reference", "[gpt2][integration]")
 {
     auto tokenizer = make_tokenizer();
+    using Tokenizer = decltype(tokenizer);
+    using TokenizerTraits = text::tokenizer_traits<Tokenizer>;
     text::gpt2_codec codec;
 
-    auto str = tokenizer.decode(125579);
+    auto str = TokenizerTraits::decode(tokenizer, 125579);
     REQUIRE(str == " استاندارد");
 
     auto output = codec.encode(str);
@@ -52,15 +54,17 @@ TEST_CASE("TEST GPT-2 to Reference", "[gpt2][integration]")
 TEST_CASE("Test BPE encode and decode", "[bpe][integration]")
 {
     auto tokenizer = make_tokenizer();
+    using Tokenizer = decltype(tokenizer);
+    using TokenizerTraits = text::tokenizer_traits<Tokenizer>;
 
-    auto ids = tokenizer.encode("This is a test sentence.");
+    auto ids = TokenizerTraits::encode(tokenizer, "This is a test sentence.");
     REQUIRE(ids.size(0) == 6);
 
     std::vector<int32_t> actual(ids.begin(), ids.end());
     std::vector<int32_t> expect = {2028, 374, 264, 1296, 11914, 13};
     REQUIRE_THAT(actual, Catch::Matchers::Equals(expect));
 
-    auto str = tokenizer.decode(ids.data_ptr(), ids.data_ptr() + ids.size(0));
+    auto str = TokenizerTraits::decode(tokenizer, ids.data_ptr(), ids.data_ptr() + ids.size(0));
     REQUIRE(str == "This is a test sentence.");
 }
 
@@ -68,7 +72,10 @@ TEST_CASE("Test BPE encode and decode", "[bpe][integration]")
 TEST_CASE("Encode pairs with byte merge", "[bpe][integration]")
 {
     auto tokenizer = make_tokenizer();
-    auto ids = tokenizer.encode("And his name is John Cena.");
+    using Tokenizer = decltype(tokenizer);
+    using TokenizerTraits = text::tokenizer_traits<Tokenizer>;
+
+    auto ids = TokenizerTraits::encode(tokenizer, "And his name is John Cena.");
 
     REQUIRE(ids.size(0) == 7);
     std::vector<int32_t> actual(ids.begin(), ids.end());
@@ -80,9 +87,12 @@ TEST_CASE("Encode pairs with byte merge", "[bpe][integration]")
 TEST_CASE("Encode ipython word", "[bpe][integration]")
 {
     auto tokenizer = make_tokenizer();
-    auto ids = tokenizer.encode(" ipython");
+    using Tokenizer = decltype(tokenizer);
+    using TokenizerTraits = text::tokenizer_traits<Tokenizer>;
 
-    auto str = tokenizer.decode(ids.data_ptr(), ids.data_ptr() + ids.size(0));
+    auto ids = TokenizerTraits::encode(tokenizer, " ipython");
+
+    auto str = TokenizerTraits::decode(tokenizer, ids.data_ptr(), ids.data_ptr() + ids.size(0));
     REQUIRE(str == " ipython");
 }
 
@@ -90,7 +100,10 @@ TEST_CASE("Encode ipython word", "[bpe][integration]")
 TEST_CASE("Encode unknown words", "[bpe][integration]")
 {
     auto tokenizer = make_tokenizer();
-    auto ids = tokenizer.encode("This is debatable topic.");
+    using Tokenizer = decltype(tokenizer);
+    using TokenizerTraits = text::tokenizer_traits<Tokenizer>;
+
+    auto ids = TokenizerTraits::encode(tokenizer, "This is debatable topic.");
 
     REQUIRE(ids.size(0) > 0);
 }
@@ -99,7 +112,10 @@ TEST_CASE("Encode unknown words", "[bpe][integration]")
 TEST_CASE("Decode control token", "[bpe][integration]")
 {
     auto tokenizer = make_tokenizer();
-    auto token = tokenizer.decode(128001);
+    using Tokenizer = decltype(tokenizer);
+    using TokenizerTraits = text::tokenizer_traits<Tokenizer>;
+
+    auto token = TokenizerTraits::decode(tokenizer, 128001);
 
     REQUIRE(token == "<|end_of_text|>");
 }

--- a/test/test_gemma.cc
+++ b/test/test_gemma.cc
@@ -30,8 +30,11 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
 
     std::vector<int32_t> ids;
     auto output = std::back_inserter(ids);
-    tokenizer.encode(text::token::begin_text, output);
-    tokenizer.encode(input_text, output);
+
+    using Tokenizer = decltype(tokenizer);
+    using TokenizerTraits = text::tokenizer_traits<Tokenizer>;
+    TokenizerTraits::encode(tokenizer, text::token::begin_text, output);
+    TokenizerTraits::encode(tokenizer, input_text, output);
 
     auto transformer = repository.retrieve_transformer("model.safetensors", options);
 
@@ -44,10 +47,10 @@ TEST_CASE("Test gemma3", "[gemma][integration]")
     auto id = transformer.transform(input0);
 
     std::cout << input_text;
-    std::cout << tokenizer.decode(id.get()[0, 0]);
+    std::cout << TokenizerTraits::decode(tokenizer, id.get()[0, 0]);
 
     for (std::size_t i = input0.size(1); i < 32; i++) {
         id = transformer.transform(id, i);
-        std::cout << tokenizer.decode(id.get()[0, 0]) << std::flush;
+        std::cout << TokenizerTraits::decode(tokenizer, id.get()[0, 0]) << std::flush;
     }
 }

--- a/test/test_huggingface.cc
+++ b/test/test_huggingface.cc
@@ -125,7 +125,10 @@ TEST_CASE("Test llama3 tokenizer loader", "[huggingface]")
     huggingface::llama3_tokenizer_loader loader;
     auto tokenizer = loader.load(input);
 
+    using Tokenizer = decltype(tokenizer);
+    using TokenizerTraits = text::tokenizer_traits<Tokenizer>;
+
     REQUIRE(tokenizer.size() == 16);
-    REQUIRE(tokenizer.decode(4) == "%");
-    REQUIRE(tokenizer.encode("#")[0] == 2);
+    REQUIRE(TokenizerTraits::decode(tokenizer, 4) == "%");
+    REQUIRE(TokenizerTraits::encode(tokenizer, "#")[0] == 2);
 }

--- a/test/test_llama.cc
+++ b/test/test_llama.cc
@@ -38,18 +38,20 @@ TEST_CASE("Test Llama3 implementation", "[llama][integration]")
 
     std::vector<int32_t> ids;
     auto output = std::back_inserter(ids);
-    tokenizer.encode(text::token::begin_text, output);
-    tokenizer.encode(input_text, output);
 
+    using Tokenizer = decltype(tokenizer);
+    using TokenizerTraits = text::tokenizer_traits<Tokenizer>;
+    TokenizerTraits::encode(tokenizer, text::token::begin_text, output);
+    TokenizerTraits::encode(tokenizer, input_text, output);
 
     auto input0 = shared_tensor(to_tensor<int32_t>({1, ids.size()}, ids.begin(), ids.end()));
     auto id = transformer.transform(input0);
 
     std::cout << input_text;
-    std::cout << tokenizer.decode(id.get()[0, 0]);
+    std::cout << TokenizerTraits::decode(tokenizer, id.get()[0, 0]);
 
     for (std::size_t i = input0.size(1); i < 64; i++) {
         id = transformer.transform(id, i);
-        std::cout << tokenizer.decode(id.get()[0, 0]) << std::flush;
+        std::cout << TokenizerTraits::decode(tokenizer, id.get()[0, 0]) << std::flush;
     }
 }

--- a/test/test_quantization.cc
+++ b/test/test_quantization.cc
@@ -80,17 +80,20 @@ TEST_CASE("Test QLoRA inference", "[quantization][integration]")
 
     std::vector<int32_t> ids;
     auto output = std::back_inserter(ids);
-    tokenizer.encode(text::token::begin_text, output);
-    tokenizer.encode(input_text, output);
+
+    using Tokenizer = decltype(tokenizer);
+    using TokenizerTraits = text::tokenizer_traits<Tokenizer>;
+    TokenizerTraits::encode(tokenizer, text::token::begin_text, output);
+    TokenizerTraits::encode(tokenizer, input_text, output);
 
     auto input0 = shared_tensor(to_tensor<int32_t>({1, ids.size()}, ids.begin(), ids.end()));
     auto id = transformer.transform(input0);
 
     std::cout << input_text;
-    std::cout << tokenizer.decode(id.get()[0, 0]);
+    std::cout << TokenizerTraits::decode(tokenizer, id.get()[0, 0]);
 
     for (std::size_t i = input0.size(1); i < 32; i++) {
         id = transformer.transform(id, i);
-        std::cout << tokenizer.decode(id.get()[0, 0]) << std::flush;
+        std::cout << TokenizerTraits::decode(tokenizer, id.get()[0, 0]) << std::flush;
     }
 }


### PR DESCRIPTION
This patch introduces `tokenizer_traits` type to group common methods that are useful for all tokenizers into a single type.

Also this patch introduces a new type hierarchy, where all base tokenizer types implement just 3 methods with simple API.