### PR TITLE
Mark `scan` methods in token scanners as overridden

### DIFF
--- a/include/metalchat/format.h
+++ b/include/metalchat/format.h
@@ -119,7 +119,7 @@ public:
     {}
 
     bool
-    scan(index_type token)
+    scan(index_type token) override
     {
         return _M_tokens.find(token) == _M_tokens.end();
     }
@@ -146,7 +146,7 @@ public:
     }
 
     bool
-    scan(index_type token)
+    scan(index_type token) override
     {
         return (++_M_scanned) < _M_lim;
     }
@@ -202,7 +202,7 @@ public:
     }
 
     bool
-    scan(index_type token)
+    scan(index_type token) override
     {
         bool result = false;
         if (_M_scanners.size() == 0) {

--- a/include/metalchat/text/unicode_tokenizer.h
+++ b/include/metalchat/text/unicode_tokenizer.h
@@ -24,6 +24,18 @@ public:
     /// The \ref unicode_tokenizer_adaptor copy constructor.
     unicode_tokenizer_adaptor(const unicode_tokenizer_adaptor&) = default;
 
+    void
+    insert(const string_type& value, index_type id)
+    {
+        Tokenizer::insert(decode_bytes(value), id);
+    }
+
+    void
+    insert_back(const string_type& value)
+    {
+        Tokenizer::insert(decode_bytes(value));
+    }
+
     template <std::output_iterator<index_type> OutputIt>
     OutputIt
     encode(const string_type& s, OutputIt output) const

--- a/program/options.cc
+++ b/program/options.cc
@@ -103,7 +103,7 @@ options_command::get(const command_context& context) const
 
     auto manifest = resolve_manifest(context, _M_command).read();
     auto model = models.find(manifest.id());
-    model_info scoped_model{.path = model.path, .manifest = manifest};
+    model_info scoped_model{.manifest = manifest, .path = model.path};
 
     auto& option_getter = _M_option_getters.at(manifest.model.architecture);
     auto option_value = option_getter(scoped_model, _M_name);
@@ -163,7 +163,7 @@ options_command::list(const command_context& context) const
     auto model = models.find(manifest.id());
     auto scope = resolve_scope(_M_command);
 
-    model_info scoped_model{.path = model.path, .manifest = manifest};
+    model_info scoped_model{.manifest = manifest, .path = model.path};
     auto& option_lister = _M_option_listers.at(manifest.model.architecture);
 
     std::vector<option> runtime_options;

--- a/src/gemma.cc
+++ b/src/gemma.cc
@@ -73,21 +73,15 @@ gemma3_tokenizer_loader::type
 gemma3_tokenizer_loader::load(std::istream& is) const
 {
     using model_type = metalchat::huggingface::detail::tokenizer;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    using codecvt_type = std::codecvt_utf8<char32_t>;
-    using convert_type = std::wstring_convert<codecvt_type, char32_t>;
-    convert_type convert;
-#pragma clang diagnostic pop
 
     auto model_file = jsoncons::decode_json<model_type>(is);
     gemma3_tokenizer_loader::type tokenizer;
 
     for (const auto& [value, key] : model_file.model.vocab) {
-        tokenizer.insert(convert.from_bytes(value), key);
+        tokenizer.insert(value, key);
     }
     for (const auto& token : model_file.added_tokens) {
-        tokenizer.insert(convert.from_bytes(token.content), token.id);
+        tokenizer.insert(token.content, token.id);
     }
 
     return tokenizer;


### PR DESCRIPTION
This patch marks `scan` method as overridden in all derivatives of `basic_token_scanner`.