### PR TITLE
Unary kernel

### DIFF
--- a/include/metalchat/accelerator.h
+++ b/include/metalchat/accelerator.h
@@ -7,8 +7,8 @@
 #include <filesystem>
 #include <unordered_map>
 
+#include <metalchat/allocator.h>
 #include <metalchat/dtype.h>
-#include <metalchat/kernel_thread.h>
 #include <metalchat/metal.h>
 
 
@@ -43,6 +43,8 @@ struct _StringHash {
 
 
 class basic_kernel;
+class kernel_thread;
+class recursive_kernel_thread;
 
 
 /// Hardware accelerator is an abstraction of the kernel execution pipeline.
@@ -128,10 +130,7 @@ public:
     /// Set allocator to the current thread.
     template <hardware_allocator_t<void> Allocator>
     void
-    set_allocator(Allocator&& alloc)
-    {
-        _M_thread->set_allocator(std::move(alloc));
-    }
+    set_allocator(Allocator&& alloc);
 
     /// Load the kernel from the kernel library.
     ///

--- a/include/metalchat/kernel.h
+++ b/include/metalchat/kernel.h
@@ -298,12 +298,52 @@ protected:
 };
 
 
+template <typename T> class unary_kernel_wrapper {
+private:
+    basic_kernel _M_kernel;
+
+public:
+    unary_kernel_wrapper(const basic_kernel& kernel)
+    : _M_kernel(kernel)
+    {}
+
+    std::string
+    name() const
+    {
+        return _M_kernel.name();
+    }
+
+    hardware_accelerator&
+    get_accelerator()
+    {
+        return _M_kernel.get_accelerator();
+    }
+
+    template <immutable_tensor_t<T> Input>
+    auto
+    operator()(Input input)
+    {
+        auto input_view = flatten<2>(input);
+        auto output_view = shared_empty_like<T>(input_view, _M_kernel.get_allocator());
+
+        auto max_threads = _M_kernel.max_threads_per_threadgroup();
+        auto [grid, thread] = make_kernel_grid_2d(input, max_threads);
+
+        auto task = kernel_task(_M_kernel, grid, thread);
+        auto task_future = task.bind_front(output_view, input_view);
+
+        auto output = future_tensor(output_view, std::move(task_future));
+        return output.view(input.shape());
+    }
+};
+
+
 template <typename T> class binary_kernel_wrapper {
 private:
     basic_kernel _M_kernel;
 
 public:
-    binary_kernel_wrapper(basic_kernel kernel)
+    binary_kernel_wrapper(const basic_kernel& kernel)
     : _M_kernel(kernel)
     {}
 

--- a/include/metalchat/kernel/activation.h
+++ b/include/metalchat/kernel/activation.h
@@ -17,7 +17,7 @@ namespace kernel {
 /// Applies the Sigmoid Linear Unit (SiLU) function, element-wise.
 template <typename T> class silu {
 private:
-    basic_kernel _M_kernel;
+    unary_kernel_wrapper<T> _M_kernel;
 
 public:
     silu(hardware_accelerator& accelerator)
@@ -28,17 +28,7 @@ public:
     auto
     operator()(Input input)
     {
-        auto input_view = flatten<2>(input);
-        auto output_view = shared_empty_like<T>(input_view, _M_kernel.get_allocator());
-
-        auto max_threads = _M_kernel.max_threads_per_threadgroup();
-        auto [grid, thread] = make_kernel_grid_2d(input, max_threads);
-
-        auto task = kernel_task(_M_kernel, grid, thread);
-        auto task_future = task.bind_front(output_view, input_view);
-
-        auto output = future_tensor(output_view, std::move(task_future));
-        return output.view(input.shape());
+        return _M_kernel(input);
     }
 };
 
@@ -46,7 +36,7 @@ public:
 /// Applies the Gaussian Error Linear Units function.
 template <typename T> class gelu {
 private:
-    basic_kernel _M_kernel;
+    unary_kernel_wrapper<T> _M_kernel;
 
 public:
     gelu(hardware_accelerator& accelerator)
@@ -57,17 +47,7 @@ public:
     auto
     operator()(Input input)
     {
-        auto input_view = flatten<2>(input);
-        auto output_view = shared_empty_like<T>(input_view, _M_kernel.get_allocator());
-
-        auto max_threads = _M_kernel.max_threads_per_threadgroup();
-        auto [grid, thread] = make_kernel_grid_2d(input, max_threads);
-
-        auto task = kernel_task(_M_kernel, grid, thread);
-        auto task_future = task.bind_front(output_view, input_view);
-
-        auto output = future_tensor(output_view, std::move(task_future));
-        return output.view(input.shape());
+        return _M_kernel(input);
     }
 };
 

--- a/include/metalchat/kernel_thread.h
+++ b/include/metalchat/kernel_thread.h
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <memory>
 
+#include <metalchat/accelerator.h>
 #include <metalchat/allocator.h>
 #include <metalchat/metal.h>
 #include <metalchat/tensor/concept.h>
@@ -292,6 +293,14 @@ public:
     std::shared_ptr<kernel_thread>
     get_this_thread();
 };
+
+
+template <hardware_allocator_t<void> Allocator>
+void
+hardware_accelerator::set_allocator(Allocator&& alloc)
+{
+    _M_thread->set_allocator(std::move(alloc));
+}
 
 
 } // namespace metalchat

--- a/include/metalchat/kernel_thread.h
+++ b/include/metalchat/kernel_thread.h
@@ -96,7 +96,7 @@ private:
     on_completed(kernel_callback_type callback);
 
 public:
-    hardware_function_encoder(std::shared_ptr<kernel_queue> queue, allocator_type alloc);
+    hardware_function_encoder(const std::shared_ptr<kernel_queue>& queue, allocator_type alloc);
 
     void
     initialize(const std::string& name, const metal::shared_kernel kernel);

--- a/include/metalchat/nn/cache.h
+++ b/include/metalchat/nn/cache.h
@@ -121,7 +121,7 @@ public:
     ///
     /// \param options caching options for the KV cache.
     /// \param accelerator a hardware accelerator instance.
-    sink_cache(const caching_options& options, hardware_accelerator accelerator)
+    sink_cache(const caching_options& options, hardware_accelerator& accelerator)
     : sink_cache(std::bit_width(options.max_seq_len) - 1, options, accelerator)
     {}
 

--- a/include/metalchat/nn/embedding.h
+++ b/include/metalchat/nn/embedding.h
@@ -57,6 +57,41 @@ public:
     using weight_type = tensor<T, 2, Container>;
     using weight_pointer = shared_tensor_ptr<weight_type>;
 
+    /// The embedding layer constructor.
+    ///
+    /// \param num_embeddings Size of the dictionary of embeddings.
+    /// \param embedding_dim Size of each embedding vector.
+    /// \param accelerator A hardware accelerator.
+    embedding(
+        std::size_t num_embeddings, std::size_t embedding_dim, hardware_accelerator& accelerator
+    )
+    : embedding(empty<T>({num_embeddings, embedding_dim}, accelerator), accelerator)
+    {}
+
+    /// The embedding layer constructor.
+    ///
+    /// \param accelerator A hardware accelerator.
+    embedding(hardware_accelerator& accelerator)
+    : embedding(shared_tensor(weight_type()), accelerator)
+    {}
+
+    Embedding::result_type
+    operator()(Embedding::input_type input)
+    {
+        return _M_embedding(input, _M_weight);
+    }
+
+    /// Formats the layer name and it's parameters.
+    friend std::ostream&
+    operator<<(std::ostream& os, const embedding& e)
+    {
+        os << "nn::embedding<" << type_traits<T>::name() << ">";
+        os << "(num_embeddings=" << e._M_weight.size(0) << ", ";
+        os << "embedding_dim=" << e._M_weight.size(1) << ")";
+        return os;
+    }
+
+private:
     embedding(weight_pointer weight_ptr, hardware_accelerator& accelerator)
     : Embedding(accelerator),
       _M_weight(weight_ptr),
@@ -69,31 +104,6 @@ public:
     : embedding(shared_tensor(std::move(weight)), accelerator)
     {}
 
-    embedding(
-        std::size_t num_embeddings, std::size_t embedding_dim, hardware_accelerator& accelerator
-    )
-    : embedding(empty<T>({num_embeddings, embedding_dim}, accelerator), accelerator)
-    {}
-
-    embedding(hardware_accelerator& accelerator)
-    : embedding(shared_tensor(weight_type()), accelerator)
-    {}
-
-    Embedding::result_type
-    operator()(Embedding::input_type input)
-    {
-        return _M_embedding(input, _M_weight);
-    }
-
-    friend std::ostream&
-    operator<<(std::ostream& os, const embedding& e)
-    {
-        os << "nn::embedding<" << type_traits<T>::name() << ">";
-        os << "(" << e._M_weight.sizes() << ")";
-        return os;
-    }
-
-private:
     weight_pointer _M_weight;
     kernel::embedding<T> _M_embedding;
 };

--- a/include/metalchat/nn/linear.h
+++ b/include/metalchat/nn/linear.h
@@ -35,9 +35,9 @@ public:
 /// Applies an affine linear transformation to the input data.
 template <typename T, contiguous_container Container = hardware_memory_container<T>>
 class linear : public basic_linear<T, Container> {
-    using _Base = basic_linear<T, Container>;
-
 public:
+    using Linear = basic_linear<T, Container>;
+
     using value_type = T;
     using container_type = Container;
     using bias_type = tensor<T, 1, Container>;
@@ -69,11 +69,11 @@ public:
     {}
 
     linear(hardware_accelerator& accelerator)
-    : _Base(accelerator),
+    : Linear(accelerator),
       _M_weight(shared_tensor(weight_type())),
       _M_bias()
     {
-        _Base::register_parameter("weight", _M_weight);
+        Linear::register_parameter("weight", _M_weight);
     }
 
     /// Enable additive bias.
@@ -83,7 +83,7 @@ public:
     void
     enable_bias()
     {
-        _Base::register_parameter("bias", _M_bias);
+        Linear::register_parameter("bias", _M_bias);
     }
 
     template <immutable_tensor_t<T> Input>
@@ -93,8 +93,8 @@ public:
         return forward(input);
     }
 
-    _Base::result_type
-    operator()(_Base::input_type input)
+    Linear::result_type
+    operator()(Linear::input_type input)
     {
         return forward(input);
     }
@@ -111,11 +111,11 @@ public:
 
 private:
     linear(weight_pointer weight_ptr, bias_pointer bias_ptr, hardware_accelerator& accelerator)
-    : _Base(accelerator),
+    : Linear(accelerator),
       _M_weight(weight_ptr),
       _M_bias(bias_ptr)
     {
-        _Base::register_parameter("weight", _M_weight);
+        Linear::register_parameter("weight", _M_weight);
         if (_M_bias) {
             enable_bias();
         }
@@ -140,9 +140,9 @@ private:
     auto
     forward(Input input)
     {
-        auto output = matmul(input, _M_weight.transpose({1, 0}), _Base::accelerator());
+        auto output = matmul(input, _M_weight.transpose({1, 0}), Linear::accelerator());
         if (_M_bias) {
-            output = add_broadcast(output, _M_bias, _Base::accelerator());
+            output = add_broadcast(output, _M_bias, Linear::accelerator());
         }
         return output;
     }

--- a/src/accelerator.cc
+++ b/src/accelerator.cc
@@ -9,6 +9,7 @@
 
 #include <metalchat/accelerator.h>
 #include <metalchat/kernel.h>
+#include <metalchat/kernel_thread.h>
 
 #include "metal_impl.h"
 

--- a/src/kernel_thread.cc
+++ b/src/kernel_thread.cc
@@ -57,7 +57,7 @@ struct kernel_queue {
 
 
 hardware_function_encoder::hardware_function_encoder(
-    std::shared_ptr<kernel_queue> queue_ptr, hardware_function_encoder::allocator_type alloc
+    const std::shared_ptr<kernel_queue>& queue_ptr, hardware_function_encoder::allocator_type alloc
 )
 : _M_allocator(alloc),
   _M_queue(queue_ptr),


### PR DESCRIPTION
This patch introduces `unary_kernel_wrapper` for unary kernels (like activations), and also modifies Embedding API, so that it does not allow to provide a custom weight through the type constructor. The possibility to override a weight remains through `nn::layer` API.