### PR TITLE
Avoid cloning output from the model

### DIFF
--- a/include/metalchat/nn/sampling.h
+++ b/include/metalchat/nn/sampling.h
@@ -247,8 +247,10 @@ public:
         using index_type = context_type::index_type;
 
         auto k = std::min(context.logits.size(1), _M_k);
-        auto values = clone(context.logits, accelerator).get();
-        auto indices = clone(context.indices, accelerator).get();
+        // This actually modifies the underlying data of the tensors, since down below
+        // we perform partial in-place sorting of the elements.
+        auto values = logits_tensor(context.logits).get();
+        auto indices = index_tensor(context.indices).get();
 
         for (std::size_t i = 0; i < indices.size(0); i++) {
             auto value = values[i].data_ptr();

--- a/src/metal_impl.h
+++ b/src/metal_impl.h
@@ -69,7 +69,7 @@ make_buffer(MTL::Buffer* p, buffer::deleter_type deleter);
 struct device {
     NS::SharedPtr<MTL::Device> ptr;
 
-    device(NS::SharedPtr<MTL::Device> p)
+    device(const NS::SharedPtr<MTL::Device>& p)
     : ptr(p)
     {}
 
@@ -87,7 +87,7 @@ struct kernel {
     NS::SharedPtr<MTL::Function> function;
     NS::SharedPtr<MTL::ComputePipelineState> pipeline;
 
-    kernel(NS::SharedPtr<MTL::Function> f, NS::SharedPtr<MTL::ComputePipelineState> p)
+    kernel(const NS::SharedPtr<MTL::Function>& f, const NS::SharedPtr<MTL::ComputePipelineState>& p)
     : function(f),
       pipeline(p)
     {}
@@ -102,7 +102,7 @@ struct kernel {
 struct library {
     NS::SharedPtr<MTL::Library> ptr;
 
-    library(NS::SharedPtr<MTL::Library> p)
+    library(const NS::SharedPtr<MTL::Library>& p)
     : ptr(p)
     {}
 


### PR DESCRIPTION
This patch removes cloning of the model output in a sampler.