### PR TITLE
Add GEMV kernel for vector x matrix multiplication

### DIFF
--- a/include/metalchat/functional/primitive.h
+++ b/include/metalchat/functional/primitive.h
@@ -25,7 +25,7 @@ template <immutable_tensor Tensor1, immutable_tensor Tensor2, std::size_t BlockS
 auto
 matmul(Tensor1 t1, Tensor2 t2, hardware_accelerator& gpu)
 {
-    kernel::bmm<typename Tensor1::value_type, BlockSize> op(gpu);
+    kernel::matmul<typename Tensor1::value_type, BlockSize> op(gpu);
     return op(t1, t2);
 }
 

--- a/include/metalchat/kernel/bmm.h
+++ b/include/metalchat/kernel/bmm.h
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// SPDX-FileCopyrightText: 2025 Yakau Bubnou
+// SPDX-FileCopyrightText: 2025-2026 Yakau Bubnou
 // SPDX-FileType: SOURCE
 
 #pragma once
+
+#include <algorithm>
+#include <bit>
 
 #include <metalchat/accelerator.h>
 #include <metalchat/dtype.h>
@@ -15,13 +18,21 @@ namespace metalchat {
 namespace kernel {
 
 
-template <typename T, std::size_t BlockSize = 8> class bmm {
+template <typename T, std::size_t BlockSize = 8> class matmul {
 private:
-    basic_kernel _M_kernel;
+    basic_kernel _M_gemm;
+    basic_kernel _M_gemv;
+
+    template <immutable_tensor3_t<T> Input, immutable_tensor3_t<T> Weight>
+    auto
+    dispatch_gemv(Input input, Weight weight)
+    {}
 
 public:
-    bmm(hardware_accelerator& gpu)
-    : _M_kernel(gpu.load<T>("bmm", BlockSize))
+    matmul(hardware_accelerator& gpu)
+    : _M_gemm(gpu.load<T>("gemm", BlockSize)),
+      _M_gemv(gpu.load<T>("gemv"))
+
     {}
 
     template <immutable_tensor3_t<T> Input, immutable_tensor3_t<T> Weight>
@@ -30,6 +41,7 @@ public:
     {
         auto num_batches = input.size(0);
         auto input_size1 = input.size(1);
+        auto dim_size = input.size(2);
         auto weight_size2 = weight.size(2);
 
         // Batched matmul does not support broadcasting operations, therefore throw an
@@ -37,8 +49,24 @@ public:
         auto expected_input =
             expected_tensor(input).same_dim(weight, 0).same_dim(weight, 2, 1).value();
 
-        auto alloc = _M_kernel.get_allocator();
+        auto alloc = _M_gemm.get_allocator();
         auto output = shared_empty<T>({num_batches, input_size1, weight_size2}, alloc);
+
+        if (input_size1 == 1) {
+            auto max_threads = _M_gemv.max_threads_per_threadgroup();
+            auto block_size = ceil_div(dim_size, max_threads);
+            auto thread_size = ceil_div(dim_size, block_size);
+
+            auto thread = dim3(thread_size);
+            auto grid = dim3(thread_size * weight_size2, num_batches);
+
+            auto task = kernel_task(_M_gemv, grid, thread);
+            auto task_future = task.bind_front(
+                flatten<2>(output), flatten<2>(expected_input), weight, scalar<int32_t>(block_size)
+            );
+
+            return future_tensor(output, std::move(task_future));
+        }
 
         auto grid = dim3(
             ceil_div(input_size1, BlockSize) * BlockSize,
@@ -46,7 +74,7 @@ public:
         );
         auto thread = dim3(BlockSize, BlockSize);
 
-        auto task = kernel_task(_M_kernel, grid, thread);
+        auto task = kernel_task(_M_gemm, grid, thread);
         auto task_future = task.bind_front(output, expected_input, weight);
 
         // A(MxK) @ B(KxN) -> C(MxN)

--- a/kernel/bmm.metal
+++ b/kernel/bmm.metal
@@ -1,17 +1,18 @@
 // vi: set filetype=cpp :
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
-// SPDX-FileCopyrightText: 2025 Yakau Bubnou
+// SPDX-FileCopyrightText: 2025-2026 Yakau Bubnou
 // SPDX-FileType: SOURCE
 
 #include <metal_common>
+#include <metal_simdgroup>
 #include <metal_stdlib>
 
 #include "kernel.h"
 #include "tensor.h"
 
 
-template <typename T> struct __bmm_parameters {
+template <typename T> struct __gemm_parameters {
     constant layout3& output_layout;
     device T* output;
     constant layout3& mat1_layout;
@@ -24,10 +25,12 @@ template <typename T> struct __bmm_parameters {
 /// Matrix multiplication mat1(b x M x K) @ mat2(b x K x N) -> C(b x M x N)
 template <typename T, uint BlockSize>
 kernel void
-bmm(__bmm_parameters<T> params,
+gemm(
+    __gemm_parameters<T> params,
     uint3 group_id [[threadgroup_position_in_grid]],
     uint3 thread_id [[thread_position_in_threadgroup]],
-    uint3 threadgroup_size [[threads_per_threadgroup]])
+    uint3 threadgroup_size [[threads_per_threadgroup]]
+)
 {
     tensor3<const T> m1(params.mat1_layout, params.mat1);
     tensor3<const T> m2(params.mat2_layout, params.mat2);
@@ -47,17 +50,17 @@ bmm(__bmm_parameters<T> params,
     const uint thread_row = thread_id.x;
     const uint thread_col = thread_id.y;
 
-    float partial = 0.0f;
+    float partial = float(0);
 
     uint r1 = block_row + thread_row;
     uint c2 = block_col + thread_col;
 
     for (uint k = 0; k < K; k += BlockSize) {
         uint c1 = k + thread_col;
-        m1_local[thread_row][thread_col] = (r1 < M && c1 < K) ? m1.at(batch, r1, c1) : 0.0f;
+        m1_local[thread_row][thread_col] = (r1 < M && c1 < K) ? m1.at(batch, r1, c1) : float(0);
 
         uint r2 = k + thread_row;
-        m2_local[thread_row][thread_col] = (r2 < K && c2 < N) ? m2.at(batch, r2, c2) : 0.0f;
+        m2_local[thread_row][thread_col] = (r2 < K && c2 < N) ? m2.at(batch, r2, c2) : float(0);
 
         threadgroup_barrier(metal::mem_flags::mem_threadgroup);
 
@@ -78,5 +81,84 @@ bmm(__bmm_parameters<T> params,
 }
 
 
-__lib_metalchat_kernel3_tiled(bmm, 8, bfloat);
-__lib_metalchat_kernel3_tiled(bmm, 8, float);
+__lib_metalchat_kernel3_tiled(gemm, 8, bfloat);
+__lib_metalchat_kernel3_tiled(gemm, 8, float);
+
+
+template <typename T> struct __gemv_parameters {
+    constant layout2& output_layout;
+    device T* output;
+    constant layout2& vec1_layout;
+    device const T* vec1;
+    constant layout3& mat2_layout;
+    device const T* mat2;
+    constant uint& block_size;
+};
+
+
+/// Vector multiplication vec1(b x K) @ mat2(b x K x N) -> C(b x N)
+template <typename T>
+kernel void
+gemv(
+    __gemv_parameters<T> params,
+    uint2 gid [[threadgroup_position_in_grid]],
+    uint2 tid [[thread_position_in_threadgroup]],
+    uint2 threadgroup_size [[threads_per_threadgroup]],
+    uint simd_tid [[thread_index_in_simdgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]]
+)
+{
+    tensor2<T> out(params.output_layout, params.output);
+    tensor2<const T> m1(params.vec1_layout, params.vec1);
+    tensor3<const T> m2(params.mat2_layout, params.mat2);
+
+    const uint K = m1.size(1);
+    const uint N = m2.size(2);
+
+    constexpr uint SimdSize = 32;
+    float threadlocal_sum = 0.0f;
+
+    const uint batch = gid.y;
+    const uint n = gid.x;
+
+    const uint begin = tid.x * params.block_size;
+    const uint end = begin + params.block_size;
+
+    for (uint k = begin; k < end && k < K && n < N; k++) {
+        threadlocal_sum += m1.at(batch, k) * m2.at(batch, k, n);
+    }
+
+    float acc = metal::simd_sum(threadlocal_sum);
+
+    threadgroup float threadgroup_total_sum[1];
+    threadgroup float threadgroup_sum[SimdSize];
+
+    if (simd_tid < SimdSize) {
+        threadgroup_sum[simd_tid] = 0;
+    }
+    threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+
+    if (simd_tid == 0) {
+        threadgroup_sum[simd_gid] = acc;
+    }
+    threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+
+    if (simd_gid == 0) {
+        acc = metal::simd_sum(threadgroup_sum[simd_tid]);
+        if (simd_tid == 0) {
+            threadgroup_total_sum[0] = acc;
+        }
+    }
+    threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+
+    if (n < N && tid.x == 0) {
+        out.at(batch, n) = T(threadgroup_total_sum[0]);
+    }
+}
+
+
+template [[host_name("gemv_bfloat")]]
+kernel void gemv<bfloat>(__gemv_parameters<bfloat>, uint2, uint2, uint2, uint, uint);
+
+template [[host_name("gemv_float")]]
+kernel void gemv<float>(__gemv_parameters<float>, uint2, uint2, uint2, uint, uint);

--- a/test/test_kernel_bmm.cc
+++ b/test/test_kernel_bmm.cc
@@ -15,10 +15,10 @@
 using namespace metalchat;
 
 
-TEST_CASE("Matmul simple", "[kernel::bmm]")
+TEST_CASE("Matmul simple", "[kernel::matmul]")
 {
     metalchat::hardware_accelerator gpu0;
-    kernel::bmm<bf16> mm(gpu0);
+    kernel::matmul<bf16> mm(gpu0);
 
     auto input1 = shared_tensor(full<bf16>({32, 32}, 2.0));
     auto input2 = shared_tensor(full<bf16>({32, 32}, 3.0));
@@ -27,13 +27,39 @@ TEST_CASE("Matmul simple", "[kernel::bmm]")
     REQUIRE(output.dim() == 2);
     REQUIRE(output.size(0) == 32);
     REQUIRE(output.size(1) == 32);
+
+    for (std::size_t i = 0; i < 32; i++) {
+        for (std::size_t j = 0; j < 32; j++) {
+            REQUIRE_THAT((output[i, j]), Catch::Matchers::WithinAbs(192.0, 0.0001));
+        }
+    }
 }
 
 
-TEST_CASE("Matmul single batch multiplication", "[kernel::bmm]")
+TEST_CASE("Matmul vector", "[kernel::matmul]")
 {
     metalchat::hardware_accelerator gpu0;
-    kernel::bmm<float> mm(gpu0);
+    kernel::matmul<bf16> mm(gpu0);
+
+    auto input1 = shared_tensor(full<bf16>({1, 32}, 2.0));
+    auto input2 = shared_tensor(full<bf16>({32, 64}, 3.0));
+    auto output = mm(input1, input2).get();
+    std::cout << output << std::endl;
+
+    REQUIRE(output.dim() == 2);
+    REQUIRE(output.size(0) == 1);
+    REQUIRE(output.size(1) == 64);
+
+    for (std::size_t i = 0; i < 64; i++) {
+        REQUIRE_THAT((output[0, i]), Catch::Matchers::WithinAbs(192.0, 0.0001));
+    }
+}
+
+
+TEST_CASE("Matmul single batch multiplication", "[kernel::matmul]")
+{
+    metalchat::hardware_accelerator gpu0;
+    kernel::matmul<float> mm(gpu0);
 
     auto input1 = shared_tensor(rand<float>({1, 5, 2048}));     // b, i, j
     auto input2 = shared_tensor(rand<float>({8192, 2048}).t()); // j, k
@@ -54,17 +80,17 @@ TEST_CASE("Matmul single batch multiplication", "[kernel::bmm]")
                     result_ik += (input1[batch, i, j] * input2[j, k]);
                 }
 
-                REQUIRE_THAT((output[batch, i, k]), Catch::Matchers::WithinAbs(result_ik, 0.0001));
+                REQUIRE_THAT((output[batch, i, k]), Catch::Matchers::WithinAbs(result_ik, 0.01));
             }
         }
     }
 }
 
 
-TEST_CASE("Matmul large 2d", "[!benchmark][kernel::bmm]")
+TEST_CASE("Matmul large 2d", "[!benchmark][kernel::matmul]")
 {
     metalchat::hardware_accelerator gpu0;
-    kernel::bmm<bf16> mm(gpu0);
+    kernel::matmul<bf16> mm(gpu0);
 
     auto input1 = shared_tensor(full<bf16>({8, 2048}, 2.0));
     auto input2 = shared_tensor(full<bf16>({2048, 128256}, 1.0));

--- a/test/test_kernel_bmm.cc
+++ b/test/test_kernel_bmm.cc
@@ -80,7 +80,7 @@ TEST_CASE("Matmul single batch multiplication", "[kernel::matmul]")
                     result_ik += (input1[batch, i, j] * input2[j, k]);
                 }
 
-                REQUIRE_THAT((output[batch, i, k]), Catch::Matchers::WithinAbs(result_ik, 0.01));
+                REQUIRE_THAT((output[batch, i, k]), Catch::Matchers::WithinAbs(result_ik, 0.0001));
             }
         }
     }


### PR DESCRIPTION
This patch adds a GEMV kernel to improve performance during the causal inference of the LLM models.