### PR TITLE
Expected tensor to comply with `immutable_tensor` concept

### DIFF
--- a/include/metalchat/kernel/arithmetic.h
+++ b/include/metalchat/kernel/arithmetic.h
@@ -50,8 +50,7 @@ public:
     auto
     operator()(Input1 input1, Input2 input2)
     {
-        auto expected_input1 =
-            expected_tensor(input1).expect(matching_dim(1, input2.size(0))).value();
+        auto expected_input1 = expected_tensor(input1).expect(matching_dim(1, input2.size(0)));
 
         auto alloc = _M_kernel.get_allocator();
         auto output = shared_empty_like<T>(expected_input1, alloc);

--- a/include/metalchat/kernel/copy.h
+++ b/include/metalchat/kernel/copy.h
@@ -35,10 +35,8 @@ private:
     auto
     copy(Input input, Output output)
     {
-        auto expected_input = expected_tensor(input)
-                                  .expect(matching_last_dim(output))
-                                  .expect(matching_numel(output))
-                                  .value();
+        auto expected_input =
+            expected_tensor(input).expect(matching_last_dim(output)).expect(matching_numel(output));
 
         auto max_threads = _M_kernel.max_threads_per_threadgroup();
         auto [grid, thread] = make_kernel_grid_2d(expected_input, max_threads);

--- a/include/metalchat/kernel/embedding.h
+++ b/include/metalchat/kernel/embedding.h
@@ -148,8 +148,7 @@ public:
     {
         auto expected_freqs_cos = expected_tensor(freqs_cos)
                                       .expect(matching_dim(1, freqs_sin.size(1)))
-                                      .expect(matching_dim(1, _M_dim / 2))
-                                      .value();
+                                      .expect(matching_dim(1, _M_dim / 2));
 
         auto max_threads = _M_kernel.max_threads_per_threadgroup();
         auto [grid, thread] = make_kernel_grid_2d(expected_freqs_cos, max_threads);

--- a/include/metalchat/kernel/matmul.h
+++ b/include/metalchat/kernel/matmul.h
@@ -39,8 +39,7 @@ public:
         // exception, when the number of batches for input tensors are different.
         auto expected_input = expected_tensor(input)
                                   .expect(matching_dim(0, weight.size(0)))
-                                  .expect(matching_dim(2, weight.size(1)))
-                                  .value();
+                                  .expect(matching_dim(2, weight.size(1)));
 
         auto alloc = _M_gemv.get_allocator();
         auto output = shared_empty<T>({num_batches, input_size1, weight_size2}, alloc);

--- a/include/metalchat/kernel/mul.h
+++ b/include/metalchat/kernel/mul.h
@@ -47,8 +47,7 @@ public:
     auto
     operator()(Input1 input1, Input2 input2)
     {
-        auto expected_input1 =
-            expected_tensor(input1).expect(matching_dim(0, input2.size(0))).value();
+        auto expected_input1 = expected_tensor(input1).expect(matching_dim(0, input2.size(0)));
         auto expected_input2 = input2;
 
         auto max_threads = _M_kernel.max_threads_per_threadgroup();

--- a/include/metalchat/kernel/rmsnorm.h
+++ b/include/metalchat/kernel/rmsnorm.h
@@ -32,7 +32,7 @@ public:
         auto dim_size = input.sizes().back();
         auto num_rows = input.numel() / dim_size;
 
-        auto expected_weight = expected_tensor(weight).expect(matching_dim(0, dim_size)).value();
+        auto expected_weight = expected_tensor(weight).expect(matching_dim(0, dim_size));
 
         auto input_view = flatten<2>(input);
         auto output_view = shared_empty_like<T>(input_view, _M_kernel.get_allocator());

--- a/include/metalchat/tensor/expected.h
+++ b/include/metalchat/tensor/expected.h
@@ -183,6 +183,11 @@ public:
 };
 
 
+/// The tensor coupled with expectations about the shape, size, dimensionality, etc. This
+/// type is used to chain tensor assertions into \ref immutable_tensor concept, so it could
+/// be used just a regular tensor in the kernel or nn library.
+///
+/// \tparam Tensor a wrapped tensor type.
 template <immutable_tensor Tensor> class expected_tensor {
     using expected_type = std::expected<Tensor, std::exception_ptr>;
     using unexpected_type = std::unexpected<std::exception_ptr>;
@@ -190,6 +195,22 @@ template <immutable_tensor Tensor> class expected_tensor {
 public:
     using tensor_type = Tensor;
     using error_type = std::exception_ptr;
+
+    static constexpr std::size_t N = tensor_type::dim();
+
+    using value_type = tensor_type::value_type;
+
+    using pointer_type = tensor_type::pointer_type;
+
+    using accessor_type = tensor_accessor;
+
+    using container_type = tensor_type::container_type;
+
+    using container_pointer = tensor_type::container_pointer;
+
+    using iterator = tensor_type::iterator;
+
+    using const_iterator = tensor_type::const_iterator;
 
     expected_tensor(tensor_type&& t)
     : _M_value(std::move(t))
@@ -212,14 +233,248 @@ public:
         return *this;
     }
 
-    tensor_type&&
+    /// See \ref tensor::dim.
+    static constexpr std::size_t
+    dim()
+    {
+        return tensor_type::dim();
+    }
+
+    explicit
+    operator bool() const noexcept
+    {
+        return _M_value;
+    }
+
+    tensor_type&
     value()
     {
         if (!_M_value.has_value()) {
             std::rethrow_exception(_M_value.error());
         }
+        return _M_value.value();
+    }
 
-        return std::move(_M_value.value());
+    const tensor_type&
+    value() const
+    {
+        if (!_M_value.has_value()) {
+            std::rethrow_exception(_M_value.error());
+        }
+        return _M_value.value();
+    }
+
+    tensor_type&
+    operator*()
+    {
+        return value();
+    }
+
+    const tensor_type&
+    operator*() const
+    {
+        return value();
+    }
+
+    /// See \ref tensor::numel.
+    std::size_t
+    numel() const
+    {
+        return value().numel();
+    }
+
+    const accessor_type&
+    accessor() const
+    {
+        return value().accessor();
+    }
+
+    accessor_type&
+    accessor()
+    {
+        return value().accessor();
+    }
+
+    container_type&
+    container() const
+    {
+        return value().container();
+    }
+
+    std::shared_ptr<basic_container>
+    container_ptr() const
+    {
+        return value().container_ptr();
+    }
+
+    void
+    set_container(const std::shared_ptr<basic_container>& ptr)
+    {
+        value().set_container(ptr);
+    }
+
+    /// See \ref tensor::data_ptr.
+    pointer_type
+    data_ptr()
+    {
+        return value().data_ptr();
+    }
+
+    /// See \ref tensor::data_ptr.
+    const pointer_type
+    data_ptr() const
+    {
+        return value().data_ptr();
+    }
+
+    /// See \ref tensor::size.
+    std::size_t
+    size(std::size_t dim) const
+    {
+        return value().size(dim);
+    }
+
+    /// See \ref tensor::sizes.
+    const std::span<std::size_t>
+    sizes() const
+    {
+        return value().sizes();
+    }
+
+    /// See \ref tensor::shape.
+    const std::span<std::size_t, N>
+    shape() const
+    {
+        return value().shape();
+    }
+
+    /// See \ref tensor::stride.
+    std::size_t
+    stride(std::size_t dim) const
+    {
+        return value().stride(dim);
+    }
+
+    /// See \ref tensor::strides.
+    const std::span<std::size_t>
+    strides() const
+    {
+        return value().strides();
+    }
+
+    /// See \ref tensor::offset.
+    std::size_t
+    offset(std::size_t dim) const
+    {
+        return value().offset(dim);
+    }
+
+    /// See \ref tensor::offsets.
+    const std::span<std::size_t>
+    offsets() const
+    {
+        return value().offsets();
+    }
+
+    /// See \ref tensor::begin.
+    iterator
+    begin()
+    {
+        return value().begin();
+    }
+
+    /// See \ref tensor::end.
+    iterator
+    end()
+    {
+        return value().end();
+    }
+
+    /// See \ref tensor::begin.
+    const_iterator
+    begin() const
+    {
+        return value().begin();
+    }
+
+    /// See \ref tensor::end.
+    const_iterator
+    end() const
+    {
+        return value().end();
+    }
+
+    /// See \ref tensor::index_select.
+    template <convertible_to_slice... SliceTypes>
+    auto
+    index_select(const SliceTypes&... slices) requires(sizeof...(slices) == N)
+    {
+        return expected_tensor(value().index_select(slices...));
+    }
+
+    /// See \ref tensor::expand_dims.
+    auto
+    expand_dims(std::size_t dim) const
+    {
+        using tensor_t = change_tensor_dimensions_t<tensor_type, N + 1>;
+        return expected_tensor<tensor_t>(value().expand_dims(dim));
+    }
+
+    /// See \ref tensor::view.
+    template <std::size_t M>
+    auto
+    view(int (&&dims)[M]) const requires(M > 0)
+    {
+        using tensor_t = change_tensor_dimensions_t<tensor_type, M>;
+        return expected_tensor<tensor_t>(value().view(std::move(dims)));
+    }
+
+    /// See \ref tensor::view.
+    template <std::size_t M>
+    auto
+    view(const std::span<int, M> dims) const
+    {
+        using tensor_t = change_tensor_dimensions_t<tensor_type, M>;
+        return expected_tensor<tensor_t>(value().view(dims));
+    }
+
+    /// See \ref tensor::view.
+    template <std::size_t M>
+    auto
+    view(const std::span<std::size_t, M> dims) const
+    {
+        using tensor_t = change_tensor_dimensions_t<tensor_type, M>;
+        return expected_tensor<tensor_t>(value().view(dims));
+    }
+
+    /// See \ref tensor::flatten.
+    template <std::size_t M>
+    auto
+    flatten() const
+    {
+        using tensor_t = change_tensor_dimensions_t<tensor_type, M>;
+        return expected_tensor<tensor_t>(value().template flatten<M>());
+    }
+
+    /// See \ref tensor::transpose.
+    expected_tensor
+    narrow(std::size_t dim, std::size_t start, std::size_t length) const
+    {
+        return expected_tensor(value().narrow(dim, start, length));
+    }
+
+    /// See \ref tensor::transpose.
+    expected_tensor
+    transpose(const std::size_t (&&dims)[N]) const
+    {
+        return expected_tensor(value().transpose(std::move(dims)));
+    }
+
+    /// See \ref tensor::layout.
+    tensor_layout<N>
+    layout() const
+    {
+        return value().layout();
     }
 
 private:

--- a/include/metalchat/tensor/future.h
+++ b/include/metalchat/tensor/future.h
@@ -527,6 +527,12 @@ template <typename Tensor, typename T>
 concept is_future_tensor3_v = is_future_tensor_v<Tensor, T, 3>;
 
 
+template <typename T, std::size_t N, std::size_t M>
+struct change_tensor_dimensions<future_tensor<T, N>, M> {
+    using type = future_tensor<T, M>;
+};
+
+
 template <
     typename T,
     std::size_t N,


### PR DESCRIPTION
This patch makes necessary adjustment to make expected tensor comply with `immutable_tensor` concept and use it as a regular tensor in the kernel scheduling logic.